### PR TITLE
add vmseries image_uri image_name

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -45,7 +45,7 @@ resource "google_compute_instance" "this" {
 
   boot_disk {
     initialize_params {
-      image = var.image
+      image = coalesce(var.image_uri, "${var.image_prefix_uri}${var.image_name}")
       type  = var.disk_type
     }
   }

--- a/modules/vmseries/variables.tf
+++ b/modules/vmseries/variables.tf
@@ -42,7 +42,22 @@ variable scopes {
   type = list(string)
 }
 
-variable image {
+variable image_prefix_uri {
+  description = "The image URI prefix, by default https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/ string. When prepended to `image_name` it should result in a full valid Google Cloud Engine image resource URI."
+  default     = "https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/"
+  type        = string
+}
+
+variable image_name {
+  description = "The image name from which to boot an instance, including the license type and the version, e.g. vmseries-byol-814, vmseries-bundle1-814, vmseries-flex-bundle2-1001. Default is vmseries-flex-bundle1-913."
+  default     = "vmseries-flex-bundle1-913"
+  type        = string
+}
+
+variable image_uri {
+  description = "The full URI to GCE image resource, the output of `gcloud compute images list --uri`. Overrides `image_name` and `image_prefix_uri` inputs."
+  default     = null
+  type        = string
 }
 
 variable tags {


### PR DESCRIPTION
Allow users to specify just the name of the image, instead of the full uri. User will have three options:

### (1) The easiest

```
image_name = "vmseries-bundle1-814"
```

### (2) Support private customized images

```
image_prefix_uri = "https://www.googleapis.com/compute/v1/projects/my-proj/global/images/"
image_name = "vmseries-custom-814"
```

### (3) Freedom

```
image_uri = "debian-cloud/debian-9"
```
