### PR TITLE
add vmseries nat_ip 

### DIFF
--- a/examples/shared_vpc_with_workspaces/nonprod.tfvars.sample
+++ b/examples/shared_vpc_with_workspaces/nonprod.tfvars.sample
@@ -26,9 +26,9 @@ regions = {
         zone     = "us-central1-a"
         name     = "fw01"
         network_interfaces_base = [
-          { public_ip = true },
-          { public_ip = true },
-          { public_ip = false },
+          { public_nat = true },
+          { public_nat = true },
+          { public_nat = false },
         ]
         network_interfaces_custom = [
           {},

--- a/examples/vmseries/main.tf
+++ b/examples/vmseries/main.tf
@@ -44,9 +44,9 @@ module "vpc" {
 
 locals {
   nic_attributes_list = [
-    { public_ip = true },
-    { public_ip = true },
-    { public_ip = false, ip_address = "192.168.2.15" },
+    { public_nat = true },
+    { public_nat = true },
+    { public_nat = false, ip_address = "192.168.2.15" },
   ]
 }
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -43,7 +43,7 @@ resource "google_compute_instance" "this" {
     content {
       dynamic "access_config" {
         # the "access_config", if present, creates a public IP address
-        for_each = try(network_interface.value.public_ip, false) ? ["one"] : []
+        for_each = try(network_interface.value.public_nat, false) ? ["one"] : []
         content {
           nat_ip = try(network_interface.value.nat_ip, null)
         }


### PR DESCRIPTION
Allow customer to specify   `nat_ip = var.brownfield_public_ip_address`

Also use `public_nat = true` instead of `public_ip = true` to avoid a confusion which one is bool and which is IP address.

[The dynamic reservations using named IP addresses will be in a separate PR.]