### PR TITLE
vmseries reserve all IPs

### DIFF
--- a/modules/vmseries/addresses.tf
+++ b/modules/vmseries/addresses.tf
@@ -1,7 +1,18 @@
+
+# Using the default ephemeral IPs on a firewall is a bad idea, because GCE often changes them.
+# While some users will just provide explicit static IP addresses (like "192.168.2.22"), we will accommodate 
+# also the remaining users - those who'd like to have dynamic IP addresses.
+#
+# We use here google_compute_address to reserve a dynamically assigned IP address as a named entity.
+# Such address will not change even if the virtual machine is stopped or removed.
+
 locals {
-  # flatten ensures that this local value is a flat list of objects, rather
+  # Terraform for_each unfortunately requires a single-dimensional map, but we have
+  # a two-dimensional input. We need two steps for conversion.
+  #
+  # First, flatten() ensures that this local value is a flat list of objects, rather
   # than a list of lists of objects.
-  flat_interfaces = flatten([
+  input_flat_interfaces = flatten([
     for instance_key, instance in var.instances : [
       for nic_key, nic in instance.network_interfaces : {
         instance_key = instance_key
@@ -11,21 +22,39 @@ locals {
       }
     ]
   ])
-  # Convert list to a map. Make sure the keys are unique.
-  interfaces = { for v in local.flat_interfaces : "${v.instance_key}-${v.nic_key}" => v }
+
+  # Convert flat list to a flat map. Make sure the keys are unique. This is used for for_each.
+  input_interfaces = { for v in local.input_flat_interfaces : "${v.instance_key}-${v.nic_key}" => v }
+
+  # The for_each will consume a flat map and produce a new flat map of dynamically-created resources.
+  # As a final step, gather results back into a handy two-dimensional map.
+  # Create a usable result - augument the input with our dynamically created resources.
+  dyn_interfaces = { for instance_key, instance in var.instances :
+    instance_key => {
+      for nic_key, nic in instance.network_interfaces :
+      nic_key => {
+        network_ip = google_compute_address.private["${instance_key}-${nic_key}"].address
+        nat_ip = (
+          # If we have been given an excplicit nat_ip, use it. Else, use our own named address.
+          try(nic.nat_ip, null) != null ?
+          nic.nat_ip
+          :
+          try(google_compute_address.public["${instance_key}-${nic_key}"].address, null)
+        )
+        public_ptr_domain_name = try(nic.public_ptr_domain_name, null)
+      }
+    }
+  }
 }
 
 data "google_compute_subnetwork" "this" {
-  for_each = local.interfaces
+  for_each = local.input_interfaces
 
   self_link = each.value.nic.subnetwork
 }
 
-// The google_compute_address reserves a dynamically assigned IP address and then names it.
-// The unnamed (ephemeral) IP is a bad idea for a firewall, because it often changes unintentionally.
-// This resource wouldn't be necessary if we only used statically assigned IP addresses.
 resource "google_compute_address" "private" {
-  for_each = local.interfaces
+  for_each = local.input_interfaces
 
   name = try(
     each.value.nic.address_name,
@@ -38,7 +67,7 @@ resource "google_compute_address" "private" {
 }
 
 resource "google_compute_address" "public" {
-  for_each = { for k, v in local.interfaces : k => v if v.nic.public_nat && try(v.nic.nat_ip, null) == null }
+  for_each = { for k, v in local.input_interfaces : k => v if v.nic.public_nat && try(v.nic.nat_ip, null) == null }
 
   name = try(
     each.value.nic.public_address_name,

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -42,21 +42,15 @@ resource "google_compute_instance" "this" {
     for_each = each.value.network_interfaces
 
     content {
-      network_ip = google_compute_address.private["${each.key}-${network_interface.key}"].address
+      network_ip = local.dyn_interfaces[each.key][network_interface.key].network_ip
       subnetwork = network_interface.value.subnetwork
 
       dynamic "access_config" {
-        # the "access_config", if present, creates a public IP address
+        # The "access_config", if present, creates a public IP address. Currently GCE only supports one, hence "one".
         for_each = try(network_interface.value.public_nat, false) ? ["one"] : []
         content {
-          nat_ip = (
-            # If we have been given a nat_ip, use it. Else use our own named address.
-            try(network_interface.value.nat_ip, null) != null ?
-            network_interface.value.nat_ip
-            :
-            google_compute_address.public["${each.key}-${network_interface.key}"].address
-          )
-          public_ptr_domain_name = try(network_interface.value.public_ptr_domain_name, null)
+          nat_ip                 = local.dyn_interfaces[each.key][network_interface.key].nat_ip
+          public_ptr_domain_name = local.dyn_interfaces[each.key][network_interface.key].public_ptr_domain_name
         }
       }
 


### PR DESCRIPTION
## Description
 
Always use `google_compute_address` to reserve a dynamically assigned IP address as a named entity.
Such address will not change even if the virtual machine is stopped or removed.
 
## Motivation and Context

Using the default ephemeral IPs on a firewall is a bad idea, because GCE often changes them.
While some users will just provide explicit static IP addresses (like "192.168.2.22"), we will accommodate 
also the remaining users - those who'd like to have dynamic IP addresses.

## How Has This Been Tested?
 
`apply` of regional_workspaces example
 
