### PR TITLE
fix: deprecated syntax

### DIFF
--- a/modules/lb_tcp_external/main.tf
+++ b/modules/lb_tcp_external/main.tf
@@ -4,41 +4,36 @@ terraform {
   }
 }
 
-locals {
-  health_check_port = var.health_check["port"]
-}
-
-resource "google_compute_forwarding_rule" "default" {
-  project               = var.project
+resource "google_compute_forwarding_rule" "this" {
   name                  = var.name
-  target                = google_compute_target_pool.default.self_link
+  target                = google_compute_target_pool.this.self_link
   load_balancing_scheme = "EXTERNAL"
   port_range            = var.service_port
-  region                = var.region
   ip_address            = var.ip_address
   ip_protocol           = var.ip_protocol
+  region                = var.region
+  project               = var.project
 }
 
-resource "google_compute_target_pool" "default" {
-  project          = var.project
+resource "google_compute_target_pool" "this" {
   name             = var.name
-  region           = var.region
   session_affinity = var.session_affinity
   instances        = var.instances
-  health_checks    = var.disable_health_check ? [] : [google_compute_http_health_check.default.0.self_link]
+  health_checks    = var.disable_health_check ? [] : [google_compute_http_health_check.this[0].self_link]
+  region           = var.region
+  project          = var.project
 }
 
-resource "google_compute_http_health_check" "default" {
-  count   = var.disable_health_check ? 0 : 1
-  project = var.project
-  name    = "${var.name}-hc"
+resource "google_compute_http_health_check" "this" {
+  count = var.disable_health_check ? 0 : 1
 
+  name                = "${var.name}-hc"
   check_interval_sec  = var.health_check["check_interval_sec"]
   healthy_threshold   = var.health_check["healthy_threshold"]
   timeout_sec         = var.health_check["timeout_sec"]
   unhealthy_threshold = var.health_check["unhealthy_threshold"]
-
-  port         = local.health_check_port == null ? var.service_port : local.health_check_port
-  request_path = var.health_check["request_path"]
-  host         = var.health_check["host"]
+  port                = coalesce(var.health_check["port"], var.service_port)
+  request_path        = var.health_check["request_path"]
+  host                = var.health_check["host"]
+  project             = var.project
 }

--- a/modules/lb_tcp_external/outputs.tf
+++ b/modules/lb_tcp_external/outputs.tf
@@ -1,11 +1,14 @@
 output forwarding_rule {
-  value = google_compute_forwarding_rule.default.*.self_link
+  description = "The self-link of the forwarding rule."
+  value       = google_compute_forwarding_rule.this.self_link
 }
 
 output address {
-  value = google_compute_forwarding_rule.default.ip_address
+  description = "The IP address of the forwarding rule."
+  value       = google_compute_forwarding_rule.this.ip_address
 }
 
 output target_pool {
-  value = google_compute_target_pool.default.self_link
+  description = "The self-link of the target pool."
+  value       = google_compute_target_pool.this.self_link
 }


### PR DESCRIPTION
Replace this.0.x with this[0].x to satisfy a tflint rule. Reference:
https://github.com/terraform-linters/tflint/blob/v0.20.2/docs/rules/terraform_deprecated_index.md

Use the `this` naming convention.

Use the neat coalesce().

Format the code.