### PR TITLE
fix(iam): add compute.networkViewer

### DIFF
--- a/modules/iam_service_account/variables.tf
+++ b/modules/iam_service_account/variables.tf
@@ -10,6 +10,7 @@ variable display_name {
 variable roles {
   description = "List of IAM role names, such as [\"roles/compute.viewer\"] or [\"project/A/roles/B\"]. The default list is suitable for Palo Alto Networks Firewall to run and publish custom metrics to GCP Stackdriver."
   default = [
+    "roles/compute.networkViewer",
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",


### PR DESCRIPTION
Add role to avoid the Panorama error during de-licensing:

```
[autoscaling] Listing instance groups failed
Required 'compute.instanceGroupManagers.list' permission
```