### PR TITLE
feat(lb_tcp_internal): add variable allow_global_access

### DIFF
--- a/modules/lb_tcp_internal/main.tf
+++ b/modules/lb_tcp_internal/main.tf
@@ -54,5 +54,6 @@ resource "google_compute_forwarding_rule" "this" {
   all_ports             = var.all_ports
   ports                 = var.ports
   subnetwork            = var.subnetwork
+  allow_global_access   = var.allow_global_access
   backend_service       = google_compute_region_backend_service.this.self_link
 }

--- a/modules/lb_tcp_internal/variables.tf
+++ b/modules/lb_tcp_internal/variables.tf
@@ -84,3 +84,9 @@ variable failover_ratio {
   default     = null
   type        = number
 }
+
+variable allow_global_access {
+  description = "(Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route."
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
add variable allow_global_access

(Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route.