### PR TITLE
fix(iam): bucket access

### DIFF
--- a/modules/iam_service_account/variables.tf
+++ b/modules/iam_service_account/variables.tf
@@ -13,6 +13,7 @@ variable roles {
     "roles/logging.logWriter",
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",
+    "roles/viewer", # to reach a bootstrap bucket (project's storage.buckets.list with bucket's roles/storage.objectViewer insufficient)
     # per https://docs.paloaltonetworks.com/vm-series/9-1/vm-series-deployment/set-up-the-vm-series-firewall-on-google-cloud-platform/deploy-vm-series-on-gcp/enable-google-stackdriver-monitoring-on-the-vm-series-firewall.html
     "roles/stackdriver.accounts.viewer",
     "roles/stackdriver.resourceMetadata.writer",


### PR DESCRIPTION
Project's storage.buckets.list with bucket's roles/storage.objectViewer
allow for `gsutil ls` and `gsutil cat` to succeed, they however still cause
"No bootstrap media detected" on a firewall.

I've tested that adding the project's Viewer role allows bootstrap to succeed.