### PR TITLE
various autoscale changes

### DIFF
--- a/modules/autoscale/main.tf
+++ b/modules/autoscale/main.tf
@@ -86,7 +86,7 @@ resource "google_compute_instance_group_manager" "this" {
   base_instance_name = "${var.prefix}-fw"
   name               = "${var.prefix}-igm-${each.value}"
   zone               = each.value
-  target_pools       = [var.pool]
+  target_pools       = compact([var.pool])
 
   version {
     instance_template = google_compute_instance_template.this.id

--- a/modules/autoscale/variables.tf
+++ b/modules/autoscale/variables.tf
@@ -109,7 +109,8 @@ variable nic2_public_ip {
 }
 
 variable pool {
-  description = "The self_link of google_compute_target_pool where the instances will be placed for healtchecking"
+  description = "The self_link of google_compute_target_pool where the auto-created instances will be placed for healtchecking of External Load Balancer"
+  default     = null
   type        = string
 }
 


### PR DESCRIPTION
## Description

### fix(autoscale): vanishing file just after update
82951ce

When init-cfg.txt is updated, the next `tf apply` first performs
Create and later Destroy. Thus the file is actually not present
in the bucket after the next `tf apply --refresh=true`.

It's the instance that needs the init-cfg.txt and so IGM should wait
here instead of the template.

The template shouldn't depend on that init-cfg.txt, moreover it passes
the create_before_destroy to the bucket causing the bug.


### feat(autoscale): ignore IGM version name changes

Ignore the name changes and only react to the version.instance_template changes.
Google webui uses dummy name changes to implement Rolling Restart.

### Add IAM role
Avoid dummy error message about unreachable Pub/Sub on Panorama GCP log.

### Make Target Pool Optional
Minor tweak when autoscaling is used without any External LB.
