### PR TITLE
fix(vmseries): no create_before_destroy

### DIFF
--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -94,9 +94,5 @@ resource "google_compute_instance_group" "this" {
       port = named_port.value.port
     }
   }
-
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 


### PR DESCRIPTION
## Description

  1. The create_before_destroy propagates via dependency chain.
  2. When replacing instance, the instance_group also needs to be replaced.

Bug: Due to 1+2 combined, a major change to instance causes the new
instance to be created *first* before the old instance is removed.
This fails: instance with that name already exists.
