### PR TITLE
fix(ci): terraform_version 0.12.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.12.29
 
       - name: terraform validate
         env:


### PR DESCRIPTION
Everything in CI should be pinned, so we're not randomly hit with upstream changes.
Presently, CI fails because incompatibilities in terraform release 0.14.