### PR TITLE
feat: gitignore extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
 .terraform/
 terraform.tfstate*
 authcodes
-id_rsa_pgs
+id_rsa*
+id_dsa*
+id_ecdsa*
+id_ed*
+!id*.pub
+venv
+.idea
+.vscode
+TODObranch.txt


### PR DESCRIPTION
Cleanup gitignore and introduce the general patterns.
Discourage committing private ssh keys (opinionless on public keys).
