### PR TITLE
fix(autoscale): intermittent max_surge error

### DIFF
--- a/modules/autoscale/main.tf
+++ b/modules/autoscale/main.tf
@@ -103,9 +103,10 @@ resource "google_compute_instance_group_manager" "this" {
   }
 
   update_policy {
-    type           = var.update_policy_type
-    min_ready_sec  = var.update_policy_min_ready_sec
-    minimal_action = "REPLACE"
+    type            = var.update_policy_type
+    min_ready_sec   = var.update_policy_min_ready_sec
+    max_surge_fixed = 1
+    minimal_action  = "REPLACE"
   }
 
   dynamic "named_port" {


### PR DESCRIPTION
Terraform complains about max_surge_fixed being 0 on some runs.
Specs say it is 1 by default. Explicitly setting 1 seems sufficient to fix this weirdness.
