### PR TITLE
feat(lb_tcp_internal): per-region health check

### DIFF
--- a/modules/lb_tcp_internal/main.tf
+++ b/modules/lb_tcp_internal/main.tf
@@ -4,8 +4,10 @@ terraform {
   }
 }
 
+data "google_client_config" "this" {}
+
 resource "google_compute_health_check" "this" {
-  name = "${var.name}-check-tcp${var.health_check_port}"
+  name = "${var.name}-${data.google_client_config.this.region}-check-tcp${var.health_check_port}"
 
   tcp_health_check {
     port = var.health_check_port


### PR DESCRIPTION
Opinionated approach to health check, identical to used in External LB.
HC as a GCP resource is just a bunch of general tunables/knobs, nothing
specific to a region or a network. And GCP docs implicitly favor
a global HC, because it assigns /global/ namespace for any HC:

https://www.googleapis.com/compute/v1/projects/MY/global/healthChecks/

It's a bad idea for two reasons:

1. When tuning production, the load and flakiness tend to diverge
a lot between markets/geographies. Soon, they need separate tuning.

2. A codebase that creates a HC in one tfstate and passes it around to a
different (per-region) tfstate is much less readable.

Thus, always create a per-region HC. The old code was hard to use
across regions, because it would require to manually change the name of
the HC for each region to avoid name conflict (the ILB name is already
allowed to be re-used in another GCP region, only HC has that problem).
It's simpler to enforce a per-region HC naming.
