### PR TITLE
docs(contributing): pre-commit required

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -3,6 +3,21 @@
 Contributions are welcome, and they are greatly appreciated! Every little bit helps,
 and credit will always be given.
 
+## Tools
+
+Any serious changes, especially any changes of variables or providers, require the
+`pre-commit` tool. It's a Python3 module, with quite simple
+[installation instruction](https://pre-commit.com/#installation).
+
+For these Contributors who prefer *not* to use the recommended git hooks, the command
+to fully update the auto-generated README files and to run formatters/tests is:
+
+```
+pre-commit run -a
+```
+
+This command does not commit anything; in fact it does not alter anything related to Git.
+
 ## Coding Standards
 
 Please follow the [Terraform conventions](terraform-conventions.md) for the project.


### PR DESCRIPTION
Require the `pre-commit` tool.

Workaround for those who do not want to run hooks (after all, `pre-commit` is just a normal python executable).