### PR TITLE
TERRAM-24: public-grade root README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ along with the changelog, on the GitHub [Releases](../../releases) page.
 Contributions are welcome, and they are greatly appreciated! Every little bit helps,
 and credit will always be given. Please follow our [contributing guide](./docs/contributing.md).
 
-## Who maintains these modules?
+<!-- ## Who maintains these modules?
 
 This repository is maintained by [Palo Alto Networks](https://www.paloaltonetworks.com/).
-<!-- If you're looking for commercial support or services, send an email to [address not known yet]. -->
+If you're looking for commercial support or services, send an email to [address not known yet]. -->


### PR DESCRIPTION
Add documentation in the root directory that would be ready for a public release to Terraform Registry.

Closes #54 
