### PR TITLE
TERRAM-57: (documentation): update docs with terraform-docs v0.12

### DIFF
--- a/examples/autoscale/README.md
+++ b/examples/autoscale/README.md
@@ -32,41 +32,62 @@ terraform apply
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12, < 0.13 |
-| google | = 3.48 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12, < 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | = 3.48 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | = 3.48 |
-| null | n/a |
+| <a name="provider_google"></a> [google](#provider\_google) | = 3.48 |
+| <a name="provider_null"></a> [null](#provider\_null) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_autoscale"></a> [autoscale](#module\_autoscale) | ../../modules/autoscale |  |
+| <a name="module_bootstrap"></a> [bootstrap](#module\_bootstrap) | ../../modules/bootstrap/ |  |
+| <a name="module_extlb"></a> [extlb](#module\_extlb) | ../../modules/lb_tcp_external/ |  |
+| <a name="module_iam_service_account"></a> [iam\_service\_account](#module\_iam\_service\_account) | ../../modules/iam_service_account/ |  |
+| <a name="module_intlb"></a> [intlb](#module\_intlb) | ../../modules/lb_tcp_internal/ |  |
+| <a name="module_jumphost"></a> [jumphost](#module\_jumphost) | ../../modules/vmseries |  |
+| <a name="module_jumpvpc"></a> [jumpvpc](#module\_jumpvpc) | ../../modules/vpc |  |
+| <a name="module_mgmt_cloud_nat"></a> [mgmt\_cloud\_nat](#module\_mgmt\_cloud\_nat) | terraform-google-modules/cloud-nat/google | ~> 1.2 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../modules/vpc |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_firewall.this](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/resources/compute_firewall) | resource |
+| [null_resource.jumphost_ssh_priv_key](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [google_compute_zones.this](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/data-sources/compute_zones) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| autoscaler\_metrics | The map with the keys being metrics identifiers (e.g. custom.googleapis.com/VMSeries/panSessionUtilization).<br>Each of the contained objects has attribute `target` which is a numerical threshold for a scale-out or a scale-in.<br>Each zonal group grows until it satisfies all the targets.<br><br>Additional optional attribute `type` defines the metric as either `GAUGE` (the default), `DELTA_PER_SECOND`, or `DELTA_PER_MINUTE`.<br>For full specification, see the `metric` inside the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler). | `map` | <pre>{<br>  "custom.googleapis.com/VMSeries/panSessionActive": {<br>    "target": 100<br>  }<br>}</pre> | no |
-| extlb\_healthcheck\_port | n/a | `number` | `80` | no |
-| extlb\_name | n/a | `string` | `"as4-fw-extlb"` | no |
-| fw\_image\_uri | Link to VM-Series PAN-OS image. Can be either a full self\_link, or one of the shortened forms per the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#image). | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/vmseries-byol-912"` | no |
-| fw\_machine\_type | n/a | `string` | `"n1-standard-4"` | no |
-| fw\_network\_ordering | A list of names from the `networks[*].name` attributes. | `list` | `[]` | no |
-| intlb\_global\_access | (Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route. | `bool` | `false` | no |
-| intlb\_name | n/a | `string` | `"as4-fw-intlb"` | no |
-| intlb\_network | Name of the defined network that will host the Internal Load Balancer. One of the names from the `networks[*].name` attribute. | `any` | n/a | yes |
-| mgmt\_network | Name of the network to create for firewall management. One of the names from the `networks[*].name` attribute. | `any` | n/a | yes |
-| mgmt\_sources | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| networks | The list of maps describing the VPC networks and subnetworks | `any` | n/a | yes |
-| prefix | Prefix to GCP resource names, an arbitrary string | `string` | `"as4"` | no |
-| private\_key\_path | Local path to private SSH key. To generate the key pair use `ssh-keygen -t rsa -C admin -N '' -f id_rsa` | `any` | `null` | no |
-| public\_key\_path | Local path to public SSH key. To generate the key pair use `ssh-keygen -t rsa -C admin -N '' -f id_rsa`  If you do not have a public key, run `ssh-keygen -f ~/.ssh/demo-key -t rsa -C admin` | `string` | `"id_rsa.pub"` | no |
-| service\_account | IAM Service Account for running firewall instances (just the identifier, without `@domain` part) | `string` | `"paloaltonetworks-fw"` | no |
+| <a name="input_autoscaler_metrics"></a> [autoscaler\_metrics](#input\_autoscaler\_metrics) | The map with the keys being metrics identifiers (e.g. custom.googleapis.com/VMSeries/panSessionUtilization).<br>Each of the contained objects has attribute `target` which is a numerical threshold for a scale-out or a scale-in.<br>Each zonal group grows until it satisfies all the targets.<br><br>Additional optional attribute `type` defines the metric as either `GAUGE` (the default), `DELTA_PER_SECOND`, or `DELTA_PER_MINUTE`.<br>For full specification, see the `metric` inside the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler). | `map` | <pre>{<br>  "custom.googleapis.com/VMSeries/panSessionActive": {<br>    "target": 100<br>  }<br>}</pre> | no |
+| <a name="input_extlb_healthcheck_port"></a> [extlb\_healthcheck\_port](#input\_extlb\_healthcheck\_port) | n/a | `number` | `80` | no |
+| <a name="input_extlb_name"></a> [extlb\_name](#input\_extlb\_name) | n/a | `string` | `"as4-fw-extlb"` | no |
+| <a name="input_fw_image_uri"></a> [fw\_image\_uri](#input\_fw\_image\_uri) | Link to VM-Series PAN-OS image. Can be either a full self\_link, or one of the shortened forms per the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#image). | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/vmseries-byol-912"` | no |
+| <a name="input_fw_machine_type"></a> [fw\_machine\_type](#input\_fw\_machine\_type) | n/a | `string` | `"n1-standard-4"` | no |
+| <a name="input_fw_network_ordering"></a> [fw\_network\_ordering](#input\_fw\_network\_ordering) | A list of names from the `networks[*].name` attributes. | `list` | `[]` | no |
+| <a name="input_intlb_global_access"></a> [intlb\_global\_access](#input\_intlb\_global\_access) | (Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route. | `bool` | `false` | no |
+| <a name="input_intlb_name"></a> [intlb\_name](#input\_intlb\_name) | n/a | `string` | `"as4-fw-intlb"` | no |
+| <a name="input_intlb_network"></a> [intlb\_network](#input\_intlb\_network) | Name of the defined network that will host the Internal Load Balancer. One of the names from the `networks[*].name` attribute. | `any` | n/a | yes |
+| <a name="input_mgmt_network"></a> [mgmt\_network](#input\_mgmt\_network) | Name of the network to create for firewall management. One of the names from the `networks[*].name` attribute. | `any` | n/a | yes |
+| <a name="input_mgmt_sources"></a> [mgmt\_sources](#input\_mgmt\_sources) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_networks"></a> [networks](#input\_networks) | The list of maps describing the VPC networks and subnetworks | `any` | n/a | yes |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to GCP resource names, an arbitrary string | `string` | `"as4"` | no |
+| <a name="input_private_key_path"></a> [private\_key\_path](#input\_private\_key\_path) | Local path to private SSH key. To generate the key pair use `ssh-keygen -t rsa -C admin -N '' -f id_rsa` | `any` | `null` | no |
+| <a name="input_public_key_path"></a> [public\_key\_path](#input\_public\_key\_path) | Local path to public SSH key. To generate the key pair use `ssh-keygen -t rsa -C admin -N '' -f id_rsa`  If you do not have a public key, run `ssh-keygen -f ~/.ssh/demo-key -t rsa -C admin` | `string` | `"id_rsa.pub"` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | IAM Service Account for running firewall instances (just the identifier, without `@domain` part) | `string` | `"paloaltonetworks-fw"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| jumphost\_ssh\_command | n/a |
-
+| <a name="output_jumphost_ssh_command"></a> [jumphost\_ssh\_command](#output\_jumphost\_ssh\_command) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/iam_service_account/README.md
+++ b/examples/iam_service_account/README.md
@@ -5,19 +5,30 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12, < 0.13 |
-| google | = 3.48 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12, < 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | = 3.48 |
 
 ## Providers
 
-No provider.
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_bootstrap"></a> [bootstrap](#module\_bootstrap) | ../../modules/bootstrap/ |  |
+| <a name="module_iam_service_account"></a> [iam\_service\_account](#module\_iam\_service\_account) | ../../modules/iam_service_account/ |  |
+| <a name="module_iam_service_account_panorama"></a> [iam\_service\_account\_panorama](#module\_iam\_service\_account\_panorama) | ../../modules/iam_service_account/ |  |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/lb_http_ext_global/README.md
+++ b/examples/lb_http_ext_global/README.md
@@ -41,29 +41,49 @@ Setting `depends_on` doesn't seem to solve this deficiency. In particular the GL
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12, < 0.13 |
-| google | = 3.48 |
-| null | = 2.1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12, < 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | = 3.48 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | = 2.1.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | = 3.48 |
-| null | = 2.1.2 |
+| <a name="provider_google"></a> [google](#provider\_google) | = 3.48 |
+| <a name="provider_null"></a> [null](#provider\_null) | = 2.1.2 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_extlb"></a> [extlb](#module\_extlb) | ../../modules/lb_tcp_external/ |  |
+| <a name="module_glb"></a> [glb](#module\_glb) | ../../modules/lb_http_ext_global |  |
+| <a name="module_ilb"></a> [ilb](#module\_ilb) | ../../modules/lb_tcp_internal |  |
+| <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries/ |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../modules/vpc/ |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_firewall.builtin_healthchecks](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.extlb](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/resources/compute_firewall) | resource |
+| [google_compute_firewall.ssh](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/resources/compute_firewall) | resource |
+| [null_resource.delay_actual_use](https://registry.terraform.io/providers/hashicorp/null/2.1.2/docs/resources/resource) | resource |
+| [null_resource.verify_with_curl](https://registry.terraform.io/providers/hashicorp/null/2.1.2/docs/resources/resource) | resource |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/data-sources/compute_zones) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| mgmt\_sources | n/a | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_mgmt_sources"></a> [mgmt\_sources](#input\_mgmt\_sources) | n/a | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| global\_url | n/a |
-| internal\_url | n/a |
-| regional\_url | n/a |
-
+| <a name="output_global_url"></a> [global\_url](#output\_global\_url) | n/a |
+| <a name="output_internal_url"></a> [internal\_url](#output\_internal\_url) | n/a |
+| <a name="output_regional_url"></a> [regional\_url](#output\_regional\_url) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/regional_workspaces/README.md
+++ b/examples/regional_workspaces/README.md
@@ -93,38 +93,49 @@ to be defined by you.
 
 | Name | Version |
 |------|---------|
-| terraform | ~>0.12 |
-| google | = 3.48 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~>0.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | = 3.48 |
 
 ## Providers
 
-No provider.
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_bootstrap"></a> [bootstrap](#module\_bootstrap) | ../../modules/bootstrap/ |  |
+| <a name="module_firewalls"></a> [firewalls](#module\_firewalls) | ../../modules/vmseries |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../modules/vpc |  |
+
+## Resources
+
+No resources.
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| auth\_file | GCP Project auth JSON file | `string` | n/a | yes |
-| develop\_locally | Go local development | `bool` | `false` | no |
-| fw\_machine\_type | VM size, e.g. n1-standard-16 | `any` | `null` | no |
-| http\_basic\_auth | The result of `echo -n 'mynewuser:newpassword' | base64` which is known by the clients of the route-operator API server. | `string` | `"bXluZXd1c2VyOm5ld3Bhc3N3b3Jk"` | no |
-| https\_cert\_pem\_file | Certificate (possibly self-signed) for the route-operator https API. The file can also contain a concatenated chain of certificates. | `string` | `"cert.pem"` | no |
-| https\_interm\_pem\_file | The parent certificate that signed `https_cert_pem_file` certificate. The X509 field Subject should equal to the X509 field Issuer of `https_cert_pem_file`. | `string` | `"interm.pem"` | no |
-| https\_key\_pem\_file | The private key file that corresponds to the first `https_cert_pem_file` certificate. | `string` | `"key.pem"` | no |
-| outbound\_route\_dest | When creating outbound routes (i.e. routes from GCP to the Internet) what destination to use. For production environment set to 0.0.0.0/0 but it can be quite a pain during tests. | `string` | n/a | yes |
-| panos\_image\_name | VM-Series license and PAN-OS (ie: vmseries-bundle1-912, vmseries-byol-814, etc) | `string` | `"vmseries-flex-byol-913"` | no |
-| prefix | Prefix to GCP resource names | `string` | n/a | yes |
-| project\_id | GCP Project ID | `string` | n/a | yes |
-| public\_key\_path | Local path to public SSH key. If you do not have a public key, run >> ssh-keygen -f ~/.ssh/demo-key -t rsa -C admin | `string` | `"~/.ssh/id_rsa.pub"` | no |
-| regions | n/a | `any` | n/a | yes |
-| ro\_ilb\_name | n/a | `string` | `""` | no |
-| ro\_ip\_address | The IP of the route-operator API. Points to an Internal Load Balancer. | `string` | `null` | no |
+| <a name="input_auth_file"></a> [auth\_file](#input\_auth\_file) | GCP Project auth JSON file | `string` | n/a | yes |
+| <a name="input_develop_locally"></a> [develop\_locally](#input\_develop\_locally) | Go local development | `bool` | `false` | no |
+| <a name="input_fw_machine_type"></a> [fw\_machine\_type](#input\_fw\_machine\_type) | VM size, e.g. n1-standard-16 | `any` | `null` | no |
+| <a name="input_http_basic_auth"></a> [http\_basic\_auth](#input\_http\_basic\_auth) | The result of `echo -n 'mynewuser:newpassword' | base64` which is known by the clients of the route-operator API server. | `string` | `"bXluZXd1c2VyOm5ld3Bhc3N3b3Jk"` | no |
+| <a name="input_https_cert_pem_file"></a> [https\_cert\_pem\_file](#input\_https\_cert\_pem\_file) | Certificate (possibly self-signed) for the route-operator https API. The file can also contain a concatenated chain of certificates. | `string` | `"cert.pem"` | no |
+| <a name="input_https_interm_pem_file"></a> [https\_interm\_pem\_file](#input\_https\_interm\_pem\_file) | The parent certificate that signed `https_cert_pem_file` certificate. The X509 field Subject should equal to the X509 field Issuer of `https_cert_pem_file`. | `string` | `"interm.pem"` | no |
+| <a name="input_https_key_pem_file"></a> [https\_key\_pem\_file](#input\_https\_key\_pem\_file) | The private key file that corresponds to the first `https_cert_pem_file` certificate. | `string` | `"key.pem"` | no |
+| <a name="input_outbound_route_dest"></a> [outbound\_route\_dest](#input\_outbound\_route\_dest) | When creating outbound routes (i.e. routes from GCP to the Internet) what destination to use. For production environment set to 0.0.0.0/0 but it can be quite a pain during tests. | `string` | n/a | yes |
+| <a name="input_panos_image_name"></a> [panos\_image\_name](#input\_panos\_image\_name) | VM-Series license and PAN-OS (ie: vmseries-bundle1-912, vmseries-byol-814, etc) | `string` | `"vmseries-flex-byol-913"` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to GCP resource names | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | n/a | yes |
+| <a name="input_public_key_path"></a> [public\_key\_path](#input\_public\_key\_path) | Local path to public SSH key. If you do not have a public key, run >> ssh-keygen -f ~/.ssh/demo-key -t rsa -C admin | `string` | `"~/.ssh/id_rsa.pub"` | no |
+| <a name="input_regions"></a> [regions](#input\_regions) | n/a | `any` | n/a | yes |
+| <a name="input_ro_ilb_name"></a> [ro\_ilb\_name](#input\_ro\_ilb\_name) | n/a | `string` | `""` | no |
+| <a name="input_ro_ip_address"></a> [ro\_ip\_address](#input\_ro\_ip\_address) | The IP of the route-operator API. Points to an Internal Load Balancer. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| info | Basic Known information output regarding region/environment/projectID |
-| management\_addresses | VM-Series Firewall Management Addresses |
-
+| <a name="output_info"></a> [info](#output\_info) | Basic Known information output regarding region/environment/projectID |
+| <a name="output_management_addresses"></a> [management\_addresses](#output\_management\_addresses) | VM-Series Firewall Management Addresses |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/vmseries/README.md
+++ b/examples/vmseries/README.md
@@ -5,26 +5,38 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12, < 0.13 |
-| google | = 3.48 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12, < 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | = 3.48 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | = 3.48 |
+| <a name="provider_google"></a> [google](#provider\_google) | = 3.48 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries |  |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | ../../modules/vpc |  |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_zones.this](https://registry.terraform.io/providers/hashicorp/google/3.48/docs/data-sources/compute_zones) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allowed\_sources | n/a | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
-| image\_uri | n/a | `any` | `null` | no |
+| <a name="input_allowed_sources"></a> [allowed\_sources](#input\_allowed\_sources) | n/a | `list` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | n/a | `any` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| ssh\_command | n/a |
-
+| <a name="output_ssh_command"></a> [ssh\_command](#output\_ssh\_command) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/autoscale/README.md
+++ b/modules/autoscale/README.md
@@ -5,60 +5,78 @@
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.48 |
-| null | ~> 2.1 |
-| random | ~> 2.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.48 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.48 |
-| null | ~> 2.1 |
-| random | ~> 2.3 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.48 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 2.3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_autoscaler.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler) | resource |
+| [google_compute_instance_group_manager.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
+| [google_compute_instance_template.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template) | resource |
+| [google_pubsub_subscription.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription) | resource |
+| [google_pubsub_subscription_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_subscription_iam_member) | resource |
+| [google_pubsub_topic.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [null_resource.dependency_getter](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_id.autoscaler](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_compute_default_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| autoscaler\_metrics | The map with the keys being metrics identifiers (e.g. custom.googleapis.com/VMSeries/panSessionUtilization).<br>Each of the contained objects has attribute `target` which is a numerical threshold for a scale-out or a scale-in.<br>Each zonal group grows until it satisfies all the targets.<br><br>Additional optional attribute `type` defines the metric as either `GAUGE` (the default), `DELTA_PER_SECOND`, or `DELTA_PER_MINUTE`.<br>For full specification, see the `metric` inside the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler). | `map` | <pre>{<br>  "custom.googleapis.com/VMSeries/panSessionThroughputKbps": {<br>    "target": 700000<br>  },<br>  "custom.googleapis.com/VMSeries/panSessionUtilization": {<br>    "target": 70<br>  }<br>}</pre> | no |
-| bootstrap\_bucket | n/a | `string` | `""` | no |
-| cooldown\_period | How much tame does it take for a spawned PA-VM to become functional on the initialization boot | `number` | `720` | no |
-| dependencies | n/a | `list(string)` | `[]` | no |
-| deployment\_name | Deployment Name that matches what is specified in Panorama GCP Plugin | `string` | n/a | yes |
-| disk\_type | n/a | `string` | `"pd-ssd"` | no |
-| image | Link to VM-Series PAN-OS image. Can be either a full self\_link, or one of the shortened forms per the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#image). | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/vmseries-byol-912"` | no |
-| machine\_type | n/a | `string` | n/a | yes |
-| max\_replicas\_per\_zone | Maximum number of VM-series instances per *each* of the zones | `number` | `1` | no |
-| mgmt\_interface\_swap | n/a | `string` | `""` | no |
-| min\_cpu\_platform | n/a | `string` | `"Intel Broadwell"` | no |
-| min\_replicas\_per\_zone | Minimum number of VM-series instances per *each* of the zones | `number` | `1` | no |
-| named\_ports | (Optional) The list of named ports:<pre>named_ports = [<br>  {<br>    name = "http"<br>    port = "80"<br>  },<br>  {<br>    name = "app42"<br>    port = "4242"<br>  },<br>]</pre>The name identifies the backend port to receive the traffic from the global load balancers. | `list` | `[]` | no |
-| nic0\_ip | n/a | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
-| nic0\_public\_ip | n/a | `bool` | `false` | no |
-| nic1\_ip | n/a | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
-| nic1\_public\_ip | n/a | `bool` | `false` | no |
-| nic2\_ip | n/a | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
-| nic2\_public\_ip | n/a | `bool` | `false` | no |
-| pool | The self\_link of google\_compute\_target\_pool where the auto-created instances will be placed for healtchecking of External Load Balancer | `string` | `null` | no |
-| prefix | Prefix to various GCP resource names | `string` | n/a | yes |
-| region | GCP region to deploy to, if not set the default provider region is used. | `string` | `null` | no |
-| scale\_in\_control\_replicas\_fixed | Fixed number of VM instances that can be killed in each zone within the scale-in time window.<br>See `scale_in_control` in the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler). | `number` | `1` | no |
-| scale\_in\_control\_time\_window\_sec | How many seconds autoscaling should look into the past when scaling in (down).<br>Default 30 minutes corresponds to the default custom metrics period of 5 minutes<br>and also to the considerable init time of a fresh instance. | `number` | `1800` | no |
-| scopes | n/a | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/compute.readonly",<br>  "https://www.googleapis.com/auth/cloud.useraccounts.readonly",<br>  "https://www.googleapis.com/auth/devstorage.read_only",<br>  "https://www.googleapis.com/auth/logging.write",<br>  "https://www.googleapis.com/auth/monitoring.write"<br>]</pre> | no |
-| service\_account | IAM Service Account for running firewall instance (just the email) | `string` | `null` | no |
-| ssh\_key | n/a | `string` | `""` | no |
-| subnetworks | n/a | `list(string)` | n/a | yes |
-| tags | n/a | `list(string)` | `[]` | no |
-| update\_policy\_min\_ready\_sec | After underlying template changes (e.g. PAN-OS upgrade) and the new instance is being spawned,<br>how long to wait after it becomes online.<br>See `update_policy` in the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager)." | `number` | `720` | no |
-| update\_policy\_type | What to do when the underlying template changes (e.g. PAN-OS upgrade).<br>OPPORTUNISTIC is the only recommended value. Also PROACTIVE is allowed: it immediately<br>starts to re-create/delete instances and since this is not coordinated with<br>the instance group manager in other zone, it can easily lead to total outage.<br>It is thus feasible only in dev environments. Real environments should<br>perform a "Rolling Update" in GCP web interface. | `string` | `"OPPORTUNISTIC"` | no |
-| zones | Map of zone names for the zonal IGMs | `map(string)` | `{}` | no |
+| <a name="input_autoscaler_metrics"></a> [autoscaler\_metrics](#input\_autoscaler\_metrics) | The map with the keys being metrics identifiers (e.g. custom.googleapis.com/VMSeries/panSessionUtilization).<br>Each of the contained objects has attribute `target` which is a numerical threshold for a scale-out or a scale-in.<br>Each zonal group grows until it satisfies all the targets.<br><br>Additional optional attribute `type` defines the metric as either `GAUGE` (the default), `DELTA_PER_SECOND`, or `DELTA_PER_MINUTE`.<br>For full specification, see the `metric` inside the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler). | `map` | <pre>{<br>  "custom.googleapis.com/VMSeries/panSessionThroughputKbps": {<br>    "target": 700000<br>  },<br>  "custom.googleapis.com/VMSeries/panSessionUtilization": {<br>    "target": 70<br>  }<br>}</pre> | no |
+| <a name="input_bootstrap_bucket"></a> [bootstrap\_bucket](#input\_bootstrap\_bucket) | n/a | `string` | `""` | no |
+| <a name="input_cooldown_period"></a> [cooldown\_period](#input\_cooldown\_period) | How much tame does it take for a spawned PA-VM to become functional on the initialization boot | `number` | `720` | no |
+| <a name="input_dependencies"></a> [dependencies](#input\_dependencies) | n/a | `list(string)` | `[]` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Deployment Name that matches what is specified in Panorama GCP Plugin | `string` | n/a | yes |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | n/a | `string` | `"pd-ssd"` | no |
+| <a name="input_image"></a> [image](#input\_image) | Link to VM-Series PAN-OS image. Can be either a full self\_link, or one of the shortened forms per the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#image). | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/vmseries-byol-912"` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | n/a | `string` | n/a | yes |
+| <a name="input_max_replicas_per_zone"></a> [max\_replicas\_per\_zone](#input\_max\_replicas\_per\_zone) | Maximum number of VM-series instances per *each* of the zones | `number` | `1` | no |
+| <a name="input_mgmt_interface_swap"></a> [mgmt\_interface\_swap](#input\_mgmt\_interface\_swap) | n/a | `string` | `""` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | n/a | `string` | `"Intel Broadwell"` | no |
+| <a name="input_min_replicas_per_zone"></a> [min\_replicas\_per\_zone](#input\_min\_replicas\_per\_zone) | Minimum number of VM-series instances per *each* of the zones | `number` | `1` | no |
+| <a name="input_named_ports"></a> [named\_ports](#input\_named\_ports) | (Optional) The list of named ports:<pre>named_ports = [<br>  {<br>    name = "http"<br>    port = "80"<br>  },<br>  {<br>    name = "app42"<br>    port = "4242"<br>  },<br>]</pre>The name identifies the backend port to receive the traffic from the global load balancers. | `list` | `[]` | no |
+| <a name="input_nic0_ip"></a> [nic0\_ip](#input\_nic0\_ip) | n/a | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_nic0_public_ip"></a> [nic0\_public\_ip](#input\_nic0\_public\_ip) | n/a | `bool` | `false` | no |
+| <a name="input_nic1_ip"></a> [nic1\_ip](#input\_nic1\_ip) | n/a | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_nic1_public_ip"></a> [nic1\_public\_ip](#input\_nic1\_public\_ip) | n/a | `bool` | `false` | no |
+| <a name="input_nic2_ip"></a> [nic2\_ip](#input\_nic2\_ip) | n/a | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
+| <a name="input_nic2_public_ip"></a> [nic2\_public\_ip](#input\_nic2\_public\_ip) | n/a | `bool` | `false` | no |
+| <a name="input_pool"></a> [pool](#input\_pool) | The self\_link of google\_compute\_target\_pool where the auto-created instances will be placed for healtchecking of External Load Balancer | `string` | `null` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to various GCP resource names | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | GCP region to deploy to, if not set the default provider region is used. | `string` | `null` | no |
+| <a name="input_scale_in_control_replicas_fixed"></a> [scale\_in\_control\_replicas\_fixed](#input\_scale\_in\_control\_replicas\_fixed) | Fixed number of VM instances that can be killed in each zone within the scale-in time window.<br>See `scale_in_control` in the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_autoscaler). | `number` | `1` | no |
+| <a name="input_scale_in_control_time_window_sec"></a> [scale\_in\_control\_time\_window\_sec](#input\_scale\_in\_control\_time\_window\_sec) | How many seconds autoscaling should look into the past when scaling in (down).<br>Default 30 minutes corresponds to the default custom metrics period of 5 minutes<br>and also to the considerable init time of a fresh instance. | `number` | `1800` | no |
+| <a name="input_scopes"></a> [scopes](#input\_scopes) | n/a | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/compute.readonly",<br>  "https://www.googleapis.com/auth/cloud.useraccounts.readonly",<br>  "https://www.googleapis.com/auth/devstorage.read_only",<br>  "https://www.googleapis.com/auth/logging.write",<br>  "https://www.googleapis.com/auth/monitoring.write"<br>]</pre> | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | IAM Service Account for running firewall instance (just the email) | `string` | `null` | no |
+| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | n/a | `string` | `""` | no |
+| <a name="input_subnetworks"></a> [subnetworks](#input\_subnetworks) | n/a | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `list(string)` | `[]` | no |
+| <a name="input_update_policy_min_ready_sec"></a> [update\_policy\_min\_ready\_sec](#input\_update\_policy\_min\_ready\_sec) | After underlying template changes (e.g. PAN-OS upgrade) and the new instance is being spawned,<br>how long to wait after it becomes online.<br>See `update_policy` in the [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager)." | `number` | `720` | no |
+| <a name="input_update_policy_type"></a> [update\_policy\_type](#input\_update\_policy\_type) | What to do when the underlying template changes (e.g. PAN-OS upgrade).<br>OPPORTUNISTIC is the only recommended value. Also PROACTIVE is allowed: it immediately<br>starts to re-create/delete instances and since this is not coordinated with<br>the instance group manager in other zone, it can easily lead to total outage.<br>It is thus feasible only in dev environments. Real environments should<br>perform a "Rolling Update" in GCP web interface. | `string` | `"OPPORTUNISTIC"` | no |
+| <a name="input_zones"></a> [zones](#input\_zones) | Map of zone names for the zonal IGMs | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| backends | Map of instance group (IG) identifiers, suitable for use in module lb\_tcp\_internal as input `backends`. |
-| instance\_group\_manager | n/a |
-
+| <a name="output_backends"></a> [backends](#output\_backends) | Map of instance group (IG) identifiers, suitable for use in module lb\_tcp\_internal as input `backends`. |
+| <a name="output_instance_group_manager"></a> [instance\_group\_manager](#output\_instance\_group\_manager) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -5,32 +5,50 @@
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
-| null | ~> 2.1 |
-| random | ~> 2.3 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
-| null | ~> 2.1 |
-| random | ~> 2.3 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 2.3 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_storage_bucket.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_object.config_empty](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.content_empty](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.file](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.license_empty](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.software_empty](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [null_resource.dependency_setter](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_string.randomstring](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [google_compute_default_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| files | Map of all files to copy to bucket. The keys are local paths, the values are remote paths. For example `{"dir/my.txt" = "config/init-cfg.txt"}` | `map(string)` | `{}` | no |
-| name\_prefix | Prefix of the name of Google Cloud Storage bucket, followed by 10 random characters | `string` | `"paloaltonetworks-firewall-bootstrap-"` | no |
-| service\_account | Optional IAM Service Account (just an email) that will be granted read-only access to this bucket | `string` | `null` | no |
+| <a name="input_files"></a> [files](#input\_files) | Map of all files to copy to bucket. The keys are local paths, the values are remote paths. For example `{"dir/my.txt" = "config/init-cfg.txt"}` | `map(string)` | `{}` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix of the name of Google Cloud Storage bucket, followed by 10 random characters | `string` | `"paloaltonetworks-firewall-bootstrap-"` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Optional IAM Service Account (just an email) that will be granted read-only access to this bucket | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| bucket | n/a |
-| bucket\_name | n/a |
-| completion | n/a |
-
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | n/a |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
+| <a name="output_completion"></a> [completion](#output\_completion) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam_service_account/README.md
+++ b/modules/iam_service_account/README.md
@@ -12,26 +12,36 @@ The account produced by this module is intended to have minimal required permiss
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_project_iam_member.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| display\_name | n/a | `string` | `"Palo Alto Networks Firewall Service Account"` | no |
-| roles | List of IAM role names, such as ["roles/compute.viewer"] or ["project/A/roles/B"]. The default list is suitable for Palo Alto Networks Firewall to run and publish custom metrics to GCP Stackdriver. | `set(string)` | <pre>[<br>  "roles/compute.networkViewer",<br>  "roles/logging.logWriter",<br>  "roles/monitoring.metricWriter",<br>  "roles/monitoring.viewer",<br>  "roles/viewer",<br>  "roles/stackdriver.accounts.viewer",<br>  "roles/stackdriver.resourceMetadata.writer"<br>]</pre> | no |
-| service\_account\_id | n/a | `string` | `"The google_service_account.account_id of the created IAM account, unique string per project."` | no |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | n/a | `string` | `"Palo Alto Networks Firewall Service Account"` | no |
+| <a name="input_roles"></a> [roles](#input\_roles) | List of IAM role names, such as ["roles/compute.viewer"] or ["project/A/roles/B"]. The default list is suitable for Palo Alto Networks Firewall to run and publish custom metrics to GCP Stackdriver. | `set(string)` | <pre>[<br>  "roles/compute.networkViewer",<br>  "roles/logging.logWriter",<br>  "roles/monitoring.metricWriter",<br>  "roles/monitoring.viewer",<br>  "roles/viewer",<br>  "roles/stackdriver.accounts.viewer",<br>  "roles/stackdriver.resourceMetadata.writer"<br>]</pre> | no |
+| <a name="input_service_account_id"></a> [service\_account\_id](#input\_service\_account\_id) | n/a | `string` | `"The google_service_account.account_id of the created IAM account, unique string per project."` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| email | n/a |
-
+| <a name="output_email"></a> [email](#output\_email) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/lb_http_ext_global/README.md
+++ b/modules/lb_http_ext_global/README.md
@@ -36,44 +36,61 @@ Thus if you re-use the same IG for this module (HTTP LB) you need balancing_mode
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_backend_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
+| [google_compute_global_address.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_forwarding_rule.http](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.https](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_health_check.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
+| [google_compute_ssl_certificate.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_ssl_certificate) | resource |
+| [google_compute_target_http_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
+| [google_compute_target_https_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_https_proxy) | resource |
+| [google_compute_url_map.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| backend\_groups | The map containing the names of instance groups (IGs) or network endpoint groups (NEGs) to serve. The IGs can be managed or unmanaged or a mix of both. All IGs must handle named port `backend_port_name`. The NEGs just handle unnamed port. | `map(string)` | `{}` | no |
-| backend\_port\_name | The port\_name of the backend groups that this load balancer will serve (default is 'http') | `string` | `"http"` | no |
-| backend\_protocol | The protocol used to talk to the backend service | `string` | `"HTTP"` | no |
-| balancing\_mode | n/a | `string` | `"RATE"` | no |
-| capacity\_scaler | n/a | `number` | `null` | no |
-| cdn | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
-| certificate | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `""` | no |
-| http\_forward | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
-| ip\_version | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `""` | no |
-| max\_connections\_per\_instance | n/a | `number` | `null` | no |
-| max\_rate\_per\_instance | n/a | `number` | `null` | no |
-| max\_utilization | n/a | `number` | `null` | no |
-| name | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
-| private\_key | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `""` | no |
-| security\_policy | The resource URL for the security policy to associate with the backend service | `string` | `""` | no |
-| ssl | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
-| ssl\_certificates | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
-| timeout\_sec | Timeout to consider a connection dead, in seconds (default 30) | `number` | `null` | no |
-| url\_map | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
-| use\_ssl\_certificates | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
+| <a name="input_backend_groups"></a> [backend\_groups](#input\_backend\_groups) | The map containing the names of instance groups (IGs) or network endpoint groups (NEGs) to serve. The IGs can be managed or unmanaged or a mix of both. All IGs must handle named port `backend_port_name`. The NEGs just handle unnamed port. | `map(string)` | `{}` | no |
+| <a name="input_backend_port_name"></a> [backend\_port\_name](#input\_backend\_port\_name) | The port\_name of the backend groups that this load balancer will serve (default is 'http') | `string` | `"http"` | no |
+| <a name="input_backend_protocol"></a> [backend\_protocol](#input\_backend\_protocol) | The protocol used to talk to the backend service | `string` | `"HTTP"` | no |
+| <a name="input_balancing_mode"></a> [balancing\_mode](#input\_balancing\_mode) | n/a | `string` | `"RATE"` | no |
+| <a name="input_capacity_scaler"></a> [capacity\_scaler](#input\_capacity\_scaler) | n/a | `number` | `null` | no |
+| <a name="input_cdn"></a> [cdn](#input\_cdn) | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
+| <a name="input_certificate"></a> [certificate](#input\_certificate) | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `""` | no |
+| <a name="input_http_forward"></a> [http\_forward](#input\_http\_forward) | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
+| <a name="input_ip_version"></a> [ip\_version](#input\_ip\_version) | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `""` | no |
+| <a name="input_max_connections_per_instance"></a> [max\_connections\_per\_instance](#input\_max\_connections\_per\_instance) | n/a | `number` | `null` | no |
+| <a name="input_max_rate_per_instance"></a> [max\_rate\_per\_instance](#input\_max\_rate\_per\_instance) | n/a | `number` | `null` | no |
+| <a name="input_max_utilization"></a> [max\_utilization](#input\_max\_utilization) | n/a | `number` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for the forwarding rule and prefix for supporting resources | `string` | n/a | yes |
+| <a name="input_private_key"></a> [private\_key](#input\_private\_key) | Content of the private SSL key. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `""` | no |
+| <a name="input_security_policy"></a> [security\_policy](#input\_security\_policy) | The resource URL for the security policy to associate with the backend service | `string` | `""` | no |
+| <a name="input_ssl"></a> [ssl](#input\_ssl) | Set to `true` to enable SSL support, requires variable `ssl_certificates` - a list of self\_link certs | `bool` | `false` | no |
+| <a name="input_ssl_certificates"></a> [ssl\_certificates](#input\_ssl\_certificates) | SSL cert self\_link list. Required if `ssl` is `true` and no `private_key` and `certificate` is provided. | `list(string)` | `[]` | no |
+| <a name="input_timeout_sec"></a> [timeout\_sec](#input\_timeout\_sec) | Timeout to consider a connection dead, in seconds (default 30) | `number` | `null` | no |
+| <a name="input_url_map"></a> [url\_map](#input\_url\_map) | The url\_map resource to use. Default is to send all traffic to first backend. | `string` | `null` | no |
+| <a name="input_use_ssl_certificates"></a> [use\_ssl\_certificates](#input\_use\_ssl\_certificates) | If true, use the certificates provided by `ssl_certificates`, otherwise, create cert from `private_key` and `certificate` | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| address | n/a |
-| all | Intended mainly for `depends_on` but currently succeeds prematurely (while forwarding rules and healtchecks are not yet usable). |
-
+| <a name="output_address"></a> [address](#output\_address) | n/a |
+| <a name="output_all"></a> [all](#output\_all) | Intended mainly for `depends_on` but currently succeeds prematurely (while forwarding rules and healtchecks are not yet usable). |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/lb_tcp_external/README.md
+++ b/modules/lb_tcp_external/README.md
@@ -13,42 +13,55 @@
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_address.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_forwarding_rule.rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
+| [google_compute_http_health_check.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | resource |
+| [google_compute_target_pool.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_pool) | resource |
+| [google_client_config.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| create\_health\_check | Whether to create a health check on the target pool. | `bool` | `true` | no |
-| health\_check\_healthy\_threshold | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
-| health\_check\_http\_host | Health check http request host header, with the default adjusted to localhost to be able to check the health of the PAN-OS webui. | `string` | `"localhost"` | no |
-| health\_check\_http\_port | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
-| health\_check\_http\_request\_path | Health check http request path, with the default adjusted to /php/login.php to be able to check the health of the PAN-OS webui. | `string` | `"/php/login.php"` | no |
-| health\_check\_interval\_sec | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
-| health\_check\_timeout\_sec | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
-| health\_check\_unhealthy\_threshold | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
-| instances | List of links to the instances. Expected to be empty when using an autoscaler, as the autoscaler inserts entries to the target pool dynamically. The nic0 of each instance gets the traffic. Even when this list is shifted or re-ordered, it doesn't re-create any resources and such modifications often proceed without any noticeable downtime. | `list(string)` | `null` | no |
-| name | Name of the target pool and of the associated healthcheck. | `string` | n/a | yes |
-| project | The project to deploy to. If unset the default provider project is used. | `string` | `""` | no |
-| region | GCP region to deploy to. If unset the default provider region is used. | `string` | `null` | no |
-| rules | Map of objects, the keys are names of the external forwarding rules, each of the objects has the following attributes:<br><br>- `port_ranges`: (Required) The port your service is listening on. Can be a number (80) or a range (8080-8089, or even 1-65535).<br>- `ip_address`: (Optional) A public IP address on which to listen, must be in the same region as the LB and must be IPv4. If empty, automatically generates a new non-ephemeral IP on a PREMIUM tier.<br>- `ip_protocol`: (Optional) The IP protocol for the frontend forwarding rule: TCP, UDP, ESP, or ICMP. Default is TCP. | `any` | n/a | yes |
-| session\_affinity | How to distribute load. Options are `NONE`, `CLIENT_IP` and `CLIENT_IP_PROTO`. | `string` | `"NONE"` | no |
+| <a name="input_create_health_check"></a> [create\_health\_check](#input\_create\_health\_check) | Whether to create a health check on the target pool. | `bool` | `true` | no |
+| <a name="input_health_check_healthy_threshold"></a> [health\_check\_healthy\_threshold](#input\_health\_check\_healthy\_threshold) | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
+| <a name="input_health_check_http_host"></a> [health\_check\_http\_host](#input\_health\_check\_http\_host) | Health check http request host header, with the default adjusted to localhost to be able to check the health of the PAN-OS webui. | `string` | `"localhost"` | no |
+| <a name="input_health_check_http_port"></a> [health\_check\_http\_port](#input\_health\_check\_http\_port) | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
+| <a name="input_health_check_http_request_path"></a> [health\_check\_http\_request\_path](#input\_health\_check\_http\_request\_path) | Health check http request path, with the default adjusted to /php/login.php to be able to check the health of the PAN-OS webui. | `string` | `"/php/login.php"` | no |
+| <a name="input_health_check_interval_sec"></a> [health\_check\_interval\_sec](#input\_health\_check\_interval\_sec) | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
+| <a name="input_health_check_timeout_sec"></a> [health\_check\_timeout\_sec](#input\_health\_check\_timeout\_sec) | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
+| <a name="input_health_check_unhealthy_threshold"></a> [health\_check\_unhealthy\_threshold](#input\_health\_check\_unhealthy\_threshold) | Health check parameter, see [provider doc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_http_health_check) | `number` | `null` | no |
+| <a name="input_instances"></a> [instances](#input\_instances) | List of links to the instances. Expected to be empty when using an autoscaler, as the autoscaler inserts entries to the target pool dynamically. The nic0 of each instance gets the traffic. Even when this list is shifted or re-ordered, it doesn't re-create any resources and such modifications often proceed without any noticeable downtime. | `list(string)` | `null` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the target pool and of the associated healthcheck. | `string` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | The project to deploy to. If unset the default provider project is used. | `string` | `""` | no |
+| <a name="input_region"></a> [region](#input\_region) | GCP region to deploy to. If unset the default provider region is used. | `string` | `null` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | Map of objects, the keys are names of the external forwarding rules, each of the objects has the following attributes:<br><br>- `port_ranges`: (Required) The port your service is listening on. Can be a number (80) or a range (8080-8089, or even 1-65535).<br>- `ip_address`: (Optional) A public IP address on which to listen, must be in the same region as the LB and must be IPv4. If empty, automatically generates a new non-ephemeral IP on a PREMIUM tier.<br>- `ip_protocol`: (Optional) The IP protocol for the frontend forwarding rule: TCP, UDP, ESP, or ICMP. Default is TCP. | `any` | n/a | yes |
+| <a name="input_session_affinity"></a> [session\_affinity](#input\_session\_affinity) | How to distribute load. Options are `NONE`, `CLIENT_IP` and `CLIENT_IP_PROTO`. | `string` | `"NONE"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| created\_health\_check | The created health check resource. Null if `create_health_check` option was false. |
-| forwarding\_rules | The map of created forwarding rules. |
-| ip\_addresses | The map of IP addresses of the forwarding rules. |
-| target\_pool | The self-link of the target pool. |
-
+| <a name="output_created_health_check"></a> [created\_health\_check](#output\_created\_health\_check) | The created health check resource. Null if `create_health_check` option was false. |
+| <a name="output_forwarding_rules"></a> [forwarding\_rules](#output\_forwarding\_rules) | The map of created forwarding rules. |
+| <a name="output_ip_addresses"></a> [ip\_addresses](#output\_ip\_addresses) | The map of IP addresses of the forwarding rules. |
+| <a name="output_target_pool"></a> [target\_pool](#output\_target\_pool) | The self-link of the target pool. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Resources Created

--- a/modules/lb_tcp_internal/README.md
+++ b/modules/lb_tcp_internal/README.md
@@ -5,41 +5,53 @@
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_forwarding_rule.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
+| [google_compute_health_check.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
+| [google_compute_region_backend_service.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_backend_service) | resource |
+| [google_client_config.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| all\_ports | Forward all ports of the ip\_protocol from the frontend to the backends. Needs to be null if `ports` are provided. | `bool` | `null` | no |
-| allow\_global\_access | (Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route. | `bool` | `false` | no |
-| backends | Names of primary backend groups (IGs or IGMs). Typically use `module.vmseries.instance_group_self_links` here. | `map(string)` | n/a | yes |
-| disable\_connection\_drain\_on\_failover | (Optional) On failover or failback, this field indicates whether connection drain will be honored. Setting this to true has the following effect: connections to the old active pool are not drained. Connections to the new active pool use the timeout of 10 min (currently fixed). Setting to false has the following effect: both old and new connections will have a drain timeout of 10 min. This can be set to true only if the protocol is TCP. The default is false. | `bool` | `null` | no |
-| drop\_traffic\_if\_unhealthy | (Optional) Used only when no healthy VMs are detected in the primary and backup instance groups. When set to true, traffic is dropped. When set to false, new connections are sent across all VMs in the primary group. The default is false. | `bool` | `null` | no |
-| failover\_backends | (Optional) Names of failover backend groups (IGs or IGMs). Failover groups are ignored unless the primary groups do not meet collective health threshold. | `map(string)` | `{}` | no |
-| failover\_ratio | (Optional) The value of the field must be in [0, 1]. If the ratio of the healthy VMs in the primary backend is at or below this number, traffic arriving at the load-balanced IP will be directed to the failover\_backends. In case where 'failoverRatio' is not set or all the VMs in the backup backend are unhealthy, the traffic will be directed back to the primary backend in the `force` mode, where traffic will be spread to the healthy VMs with the best effort, or to all VMs when no VM is healthy. This field is only used with l4 load balancing. | `number` | `null` | no |
-| health\_check | (Optional) Name of either the global google\_compute\_health\_check or google\_compute\_region\_health\_check to use. Conflicts with health\_check\_port. | `string` | `null` | no |
-| health\_check\_port | (Optional) Port number for TCP healthchecking, default 22. This setting is ignored when `health_check` is provided. | `number` | `22` | no |
-| ip\_address | n/a | `any` | `null` | no |
-| ip\_protocol | n/a | `string` | `"TCP"` | no |
-| name | Name of the load balancer (that is, both the forwarding rule and the backend service) | `string` | n/a | yes |
-| network | n/a | `any` | `null` | no |
-| ports | Which port numbers are forwarded to the backends (up to 5 ports). Conflicts with all\_ports. | `list(number)` | `[]` | no |
-| session\_affinity | (Optional, TCP only) Try to direct sessions to the same backend, can be: CLIENT\_IP, CLIENT\_IP\_PORT\_PROTO, CLIENT\_IP\_PROTO, NONE (default is NONE). | `string` | `null` | no |
-| subnetwork | n/a | `string` | n/a | yes |
-| timeout\_sec | (Optional) How many seconds to wait for the backend before dropping the connection. Default is 30 seconds. Valid range is [1, 86400]. | `number` | `null` | no |
+| <a name="input_all_ports"></a> [all\_ports](#input\_all\_ports) | Forward all ports of the ip\_protocol from the frontend to the backends. Needs to be null if `ports` are provided. | `bool` | `null` | no |
+| <a name="input_allow_global_access"></a> [allow\_global\_access](#input\_allow\_global\_access) | (Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route. | `bool` | `false` | no |
+| <a name="input_backends"></a> [backends](#input\_backends) | Names of primary backend groups (IGs or IGMs). Typically use `module.vmseries.instance_group_self_links` here. | `map(string)` | n/a | yes |
+| <a name="input_disable_connection_drain_on_failover"></a> [disable\_connection\_drain\_on\_failover](#input\_disable\_connection\_drain\_on\_failover) | (Optional) On failover or failback, this field indicates whether connection drain will be honored. Setting this to true has the following effect: connections to the old active pool are not drained. Connections to the new active pool use the timeout of 10 min (currently fixed). Setting to false has the following effect: both old and new connections will have a drain timeout of 10 min. This can be set to true only if the protocol is TCP. The default is false. | `bool` | `null` | no |
+| <a name="input_drop_traffic_if_unhealthy"></a> [drop\_traffic\_if\_unhealthy](#input\_drop\_traffic\_if\_unhealthy) | (Optional) Used only when no healthy VMs are detected in the primary and backup instance groups. When set to true, traffic is dropped. When set to false, new connections are sent across all VMs in the primary group. The default is false. | `bool` | `null` | no |
+| <a name="input_failover_backends"></a> [failover\_backends](#input\_failover\_backends) | (Optional) Names of failover backend groups (IGs or IGMs). Failover groups are ignored unless the primary groups do not meet collective health threshold. | `map(string)` | `{}` | no |
+| <a name="input_failover_ratio"></a> [failover\_ratio](#input\_failover\_ratio) | (Optional) The value of the field must be in [0, 1]. If the ratio of the healthy VMs in the primary backend is at or below this number, traffic arriving at the load-balanced IP will be directed to the failover\_backends. In case where 'failoverRatio' is not set or all the VMs in the backup backend are unhealthy, the traffic will be directed back to the primary backend in the `force` mode, where traffic will be spread to the healthy VMs with the best effort, or to all VMs when no VM is healthy. This field is only used with l4 load balancing. | `number` | `null` | no |
+| <a name="input_health_check"></a> [health\_check](#input\_health\_check) | (Optional) Name of either the global google\_compute\_health\_check or google\_compute\_region\_health\_check to use. Conflicts with health\_check\_port. | `string` | `null` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | (Optional) Port number for TCP healthchecking, default 22. This setting is ignored when `health_check` is provided. | `number` | `22` | no |
+| <a name="input_ip_address"></a> [ip\_address](#input\_ip\_address) | n/a | `any` | `null` | no |
+| <a name="input_ip_protocol"></a> [ip\_protocol](#input\_ip\_protocol) | n/a | `string` | `"TCP"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the load balancer (that is, both the forwarding rule and the backend service) | `string` | n/a | yes |
+| <a name="input_network"></a> [network](#input\_network) | n/a | `any` | `null` | no |
+| <a name="input_ports"></a> [ports](#input\_ports) | Which port numbers are forwarded to the backends (up to 5 ports). Conflicts with all\_ports. | `list(number)` | `[]` | no |
+| <a name="input_session_affinity"></a> [session\_affinity](#input\_session\_affinity) | (Optional, TCP only) Try to direct sessions to the same backend, can be: CLIENT\_IP, CLIENT\_IP\_PORT\_PROTO, CLIENT\_IP\_PROTO, NONE (default is NONE). | `string` | `null` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | n/a | `string` | n/a | yes |
+| <a name="input_timeout_sec"></a> [timeout\_sec](#input\_timeout\_sec) | (Optional) How many seconds to wait for the backend before dropping the connection. Default is 30 seconds. Valid range is [1, 86400]. | `number` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| address | n/a |
-| forwarding\_rule | n/a |
-
+| <a name="output_address"></a> [address](#output\_address) | n/a |
+| <a name="output_forwarding_rule"></a> [forwarding\_rule](#output\_forwarding\_rule) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/panorama/README.md
+++ b/modules/panorama/README.md
@@ -1,0 +1,70 @@
+# Panorama Module
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_address.private](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.public](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_disk.panorama_logs1](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+| [google_compute_disk.panorama_logs2](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+| [google_compute_image.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_image) | resource |
+| [google_compute_instance.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
+| [google_storage_bucket.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_object.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_compute_subnetwork.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of boot disk in gigabytes. Default is the same as the os image. | `string` | `null` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of boot disk. Default is pd-ssd, alternative is pd-balanced. | `string` | `"pd-ssd"` | no |
+| <a name="input_image_create_timeout"></a> [image\_create\_timeout](#input\_image\_create\_timeout) | (Optional) Timeout for uploading the *.tar.gz custom image file into the Google bucket. Default is `180m` (180 minutes). | `string` | `"180m"` | no |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The image name from which to boot an instance, including the license type and the version, e.g. panorama-byol-901, panorama-byol-1000. Default is panorama-byol-912. | `string` | `"panorama-byol-912"` | no |
+| <a name="input_image_prefix_uri"></a> [image\_prefix\_uri](#input\_image\_prefix\_uri) | The image URI prefix, by default https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/ string. When prepended to `image_name` it should result in a full valid Google Cloud Engine image resource URI. | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/"` | no |
+| <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The full URI to GCE image resource, the output of `gcloud compute images list --uri`. Overrides `image_name` and `image_prefix_uri` inputs. | `string` | `null` | no |
+| <a name="input_instances"></a> [instances](#input\_instances) | Definition of Panorama cloud instances | `map(any)` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `map(any)` | `{}` | no |
+| <a name="input_log_disk_size"></a> [log\_disk\_size](#input\_log\_disk\_size) | Size of disk holding traffic logs in gigabytes. Default is 2000. | `string` | `"2000"` | no |
+| <a name="input_log_disk_type"></a> [log\_disk\_type](#input\_log\_disk\_type) | Type of disk holding traffic logs. Default is pd-standard, alternative is pd-ssd or pd-balanced. | `string` | `"pd-standard"` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `string` | `"n1-standard-16"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `map(string)` | `{}` | no |
+| <a name="input_metadata_startup_script"></a> [metadata\_startup\_script](#input\_metadata\_startup\_script) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `string` | `null` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `string` | `"Intel Broadwell"` | no |
+| <a name="input_panorama_bucket_name"></a> [panorama\_bucket\_name](#input\_panorama\_bucket\_name) | (Optional) Bucket name used to hold the customized Panorama OS image. Used only when `panorama_image_file_name` is set. | `string` | `"paloaltonetworks-panorama-os-image-bucket"` | no |
+| <a name="input_panorama_image_file_name"></a> [panorama\_image\_file\_name](#input\_panorama\_image\_file\_name) | (Optional) Local filesystem file name (without the path component) of the file downloaded from https://support.paloaltonetworks.com from Software Updates - Panorama Base Images - GCP. The extension should be included (usually it is *.tar.gz). By default empty, which means to use either `image_name` or `image_uri` that point to a pre-existing image. | `string` | `""` | no |
+| <a name="input_panorama_image_file_path"></a> [panorama\_image\_file\_path](#input\_panorama\_image\_file\_path) | (Optional) Local filesystem path for the `panorama_image_file_name`. Used only when `panorama_image_file_name` is set. The *.tag.gz file is expected to be present at `panorama_image_file_path/panorama_image_file_name`. | `string` | `"."` | no |
+| <a name="input_project"></a> [project](#input\_project) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `string` | `null` | no |
+| <a name="input_public_nat"></a> [public\_nat](#input\_public\_nat) | n/a | `bool` | `false` | no |
+| <a name="input_resource_policies"></a> [resource\_policies](#input\_resource\_policies) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `list(string)` | `[]` | no |
+| <a name="input_scopes"></a> [scopes](#input\_scopes) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/compute.readonly",<br>  "https://www.googleapis.com/auth/cloud.useraccounts.readonly",<br>  "https://www.googleapis.com/auth/devstorage.read_only",<br>  "https://www.googleapis.com/auth/logging.write",<br>  "https://www.googleapis.com/auth/monitoring.write"<br>]</pre> | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | IAM Service Account for running the instance (just the email) | `string` | `null` | no |
+| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | n/a | `string` | `""` | no |
+| <a name="input_storage_uri"></a> [storage\_uri](#input\_storage\_uri) | (Optional) Custom URI prefix for Google Cloud Storage API. | `string` | `"https://storage.cloud.google.com"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | See the [Terraform manual](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nic0_private_ips"></a> [nic0\_private\_ips](#output\_nic0\_private\_ips) | n/a |
+| <a name="output_nic0_public_ips"></a> [nic0\_public\_ips](#output\_nic0\_public\_ips) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vmseries/README.md
+++ b/modules/vmseries/README.md
@@ -11,57 +11,71 @@ When troubleshooting you can use this module also with a good ol' Linux image. I
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
-| null | ~> 2.1 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.30 |
-| null | ~> 2.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 2.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_address.private](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.public](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_instance.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
+| [google_compute_instance_group.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group) | resource |
+| [null_resource.dependency_getter](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [google_compute_subnetwork.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| bootstrap\_bucket | n/a | `string` | `""` | no |
-| create\_instance\_group | n/a | `bool` | `false` | no |
-| dependencies | n/a | `list(string)` | `[]` | no |
-| disk\_type | Default is pd-ssd, alternative is pd-balanced. | `string` | `"pd-ssd"` | no |
-| image\_name | The image name from which to boot an instance, including the license type and the version, e.g. vmseries-byol-814, vmseries-bundle1-814, vmseries-flex-bundle2-1001. Default is vmseries-flex-bundle1-913. | `string` | `"vmseries-flex-bundle1-913"` | no |
-| image\_prefix\_uri | The image URI prefix, by default https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/ string. When prepended to `image_name` it should result in a full valid Google Cloud Engine image resource URI. | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/"` | no |
-| image\_uri | The full URI to GCE image resource, the output of `gcloud compute images list --uri`. Overrides `image_name` and `image_prefix_uri` inputs. | `string` | `null` | no |
-| instances | Definition of firewalls that will be deployed | `map(any)` | n/a | yes |
-| labels | n/a | `map(any)` | `{}` | no |
-| machine\_type | Firewall instance machine type, which depends on the license used. See the [Terraform manual](https://www.terraform.io/docs/providers/google/r/compute_instance.html) | `string` | `"n1-standard-4"` | no |
-| metadata | n/a | `map(string)` | `{}` | no |
-| metadata\_startup\_script | See the [Terraform manual](https://www.terraform.io/docs/providers/google/r/compute_instance.html) | `string` | `null` | no |
-| min\_cpu\_platform | n/a | `string` | `"Intel Broadwell"` | no |
-| named\_ports | (Optional) The list of named ports:<pre>named_ports = [<br>  {<br>    name = "http"<br>    port = "80"<br>  },<br>  {<br>    name = "app42"<br>    port = "4242"<br>  },<br>]</pre>The name identifies the backend port to receive the traffic from the global load balancers.<br>Practically, tcp port 80 named "http" works even when not defined here, but it's not a documented provider's behavior. | `list` | `[]` | no |
-| project | n/a | `string` | `null` | no |
-| resource\_policies | n/a | `list(string)` | `[]` | no |
-| scopes | n/a | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/compute.readonly",<br>  "https://www.googleapis.com/auth/cloud.useraccounts.readonly",<br>  "https://www.googleapis.com/auth/devstorage.read_only",<br>  "https://www.googleapis.com/auth/logging.write",<br>  "https://www.googleapis.com/auth/monitoring.write"<br>]</pre> | no |
-| service\_account | IAM Service Account for running firewall instance (just the email) | `string` | `null` | no |
-| ssh\_key | n/a | `string` | `""` | no |
-| tags | n/a | `list(string)` | `[]` | no |
+| <a name="input_bootstrap_bucket"></a> [bootstrap\_bucket](#input\_bootstrap\_bucket) | n/a | `string` | `""` | no |
+| <a name="input_create_instance_group"></a> [create\_instance\_group](#input\_create\_instance\_group) | n/a | `bool` | `false` | no |
+| <a name="input_dependencies"></a> [dependencies](#input\_dependencies) | n/a | `list(string)` | `[]` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Default is pd-ssd, alternative is pd-balanced. | `string` | `"pd-ssd"` | no |
+| <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The image name from which to boot an instance, including the license type and the version, e.g. vmseries-byol-814, vmseries-bundle1-814, vmseries-flex-bundle2-1001. Default is vmseries-flex-bundle1-913. | `string` | `"vmseries-flex-bundle1-913"` | no |
+| <a name="input_image_prefix_uri"></a> [image\_prefix\_uri](#input\_image\_prefix\_uri) | The image URI prefix, by default https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/ string. When prepended to `image_name` it should result in a full valid Google Cloud Engine image resource URI. | `string` | `"https://www.googleapis.com/compute/v1/projects/paloaltonetworksgcp-public/global/images/"` | no |
+| <a name="input_image_uri"></a> [image\_uri](#input\_image\_uri) | The full URI to GCE image resource, the output of `gcloud compute images list --uri`. Overrides `image_name` and `image_prefix_uri` inputs. | `string` | `null` | no |
+| <a name="input_instances"></a> [instances](#input\_instances) | Definition of firewalls that will be deployed | `map(any)` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | n/a | `map(any)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Firewall instance machine type, which depends on the license used. See the [Terraform manual](https://www.terraform.io/docs/providers/google/r/compute_instance.html) | `string` | `"n1-standard-4"` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | n/a | `map(string)` | `{}` | no |
+| <a name="input_metadata_startup_script"></a> [metadata\_startup\_script](#input\_metadata\_startup\_script) | See the [Terraform manual](https://www.terraform.io/docs/providers/google/r/compute_instance.html) | `string` | `null` | no |
+| <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | n/a | `string` | `"Intel Broadwell"` | no |
+| <a name="input_named_ports"></a> [named\_ports](#input\_named\_ports) | (Optional) The list of named ports:<pre>named_ports = [<br>  {<br>    name = "http"<br>    port = "80"<br>  },<br>  {<br>    name = "app42"<br>    port = "4242"<br>  },<br>]</pre>The name identifies the backend port to receive the traffic from the global load balancers.<br>Practically, tcp port 80 named "http" works even when not defined here, but it's not a documented provider's behavior. | `list` | `[]` | no |
+| <a name="input_project"></a> [project](#input\_project) | n/a | `string` | `null` | no |
+| <a name="input_resource_policies"></a> [resource\_policies](#input\_resource\_policies) | n/a | `list(string)` | `[]` | no |
+| <a name="input_scopes"></a> [scopes](#input\_scopes) | n/a | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/compute.readonly",<br>  "https://www.googleapis.com/auth/cloud.useraccounts.readonly",<br>  "https://www.googleapis.com/auth/devstorage.read_only",<br>  "https://www.googleapis.com/auth/logging.write",<br>  "https://www.googleapis.com/auth/monitoring.write"<br>]</pre> | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | IAM Service Account for running firewall instance (just the email) | `string` | `null` | no |
+| <a name="input_ssh_key"></a> [ssh\_key](#input\_ssh\_key) | n/a | `string` | `""` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `list(string)` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| instance\_group\_self\_links | n/a |
-| instance\_groups | n/a |
-| instances | n/a |
-| names | n/a |
-| nic0\_ips | Map of IP addresses of interface at index 0, one entry per each instance. Contains public IP if one exists, otherwise private IP. |
-| nic0\_private\_ips | n/a |
-| nic0\_public\_ips | n/a |
-| nic1\_ips | Map of IP addresses of interface at index 1, one entry per each instance. Contains public IP if one exists, otherwise private IP. |
-| nic1\_private\_ips | n/a |
-| nic1\_public\_ips | n/a |
-| private\_ips | n/a |
-| public\_ips | n/a |
-| self\_links | n/a |
-
+| <a name="output_instance_group_self_links"></a> [instance\_group\_self\_links](#output\_instance\_group\_self\_links) | n/a |
+| <a name="output_instance_groups"></a> [instance\_groups](#output\_instance\_groups) | n/a |
+| <a name="output_instances"></a> [instances](#output\_instances) | n/a |
+| <a name="output_names"></a> [names](#output\_names) | n/a |
+| <a name="output_nic0_ips"></a> [nic0\_ips](#output\_nic0\_ips) | Map of IP addresses of interface at index 0, one entry per each instance. Contains public IP if one exists, otherwise private IP. |
+| <a name="output_nic0_private_ips"></a> [nic0\_private\_ips](#output\_nic0\_private\_ips) | n/a |
+| <a name="output_nic0_public_ips"></a> [nic0\_public\_ips](#output\_nic0\_public\_ips) | n/a |
+| <a name="output_nic1_ips"></a> [nic1\_ips](#output\_nic1\_ips) | Map of IP addresses of interface at index 1, one entry per each instance. Contains public IP if one exists, otherwise private IP. |
+| <a name="output_nic1_private_ips"></a> [nic1\_private\_ips](#output\_nic1\_private\_ips) | n/a |
+| <a name="output_nic1_public_ips"></a> [nic1\_public\_ips](#output\_nic1\_public\_ips) | n/a |
+| <a name="output_private_ips"></a> [private\_ips](#output\_private\_ips) | n/a |
+| <a name="output_public_ips"></a> [public\_ips](#output\_public\_ips) | n/a |
+| <a name="output_self_links"></a> [self\_links](#output\_self\_links) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -8,29 +8,42 @@ Any existing networks/subnetworks can work equally well, independent on how they
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12, < 0.13 |
-| google | ~> 3.33 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12, < 0.13 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.33 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| google | ~> 3.33 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.33 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_firewall.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network) | resource |
+| [google_compute_subnetwork.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork) | resource |
+| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
+| [google_compute_subnetwork.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allowed\_ports | A list of ports to pass for the `networks` entries that do not have their own `allowed_ports` attribute. For example ["22", "443"]. Can also include ranges, for example ["80", "8080-8999"]. Empty list means to allow all. | `list(string)` | `[]` | no |
-| allowed\_protocol | A protocol (TCP or UDP) to pass for the `networks` entries that do not have their own `allowed_protocol` attribute. | `string` | `"all"` | no |
-| networks | Map of networks, a minimal example:<pre>{<br>  "my-vpc" = {<br>    name            = "my-vpc"<br>    subnetwork_name = "my-subnet"<br>    ip_cidr_range   = "192.168.1.0/24"<br>  }<br>}</pre>An advanced example:<pre>{<br>  "my-vpc" = {<br>    name            = "my-vpc"<br>    subnetwork_name = "my-subnet"<br>    ip_cidr_range   = "192.168.1.0/24"<br>    allowed_sources = ["209.85.152.0/22"]<br>    log_metadata    = "INCLUDE_ALL_METADATA"<br>  }<br>}</pre>Full example:<pre>{<br>  "my-vpc" = {<br>    name             = "my-vpc"<br>    subnetwork_name  = "my-subnet"<br>    ip_cidr_range    = "192.168.1.0/24"<br>    allowed_sources  = ["10.0.0.0/8", "98.98.98.0/28"]<br>    allowed_protocol = "UDP"<br>    allowed_ports    = ["53", "123-125"]<br>    log_metadata     = "EXCLUDE_ALL_METADATA"<br><br>    delete_default_routes_on_create = true<br>  }<br>  "imported-from-hostproject" = {<br>    name              = "existing-core-vpc"<br>    subnetwork_name   = "existing-subnet"<br>    create_network    = false<br>    create_subnetwork = false<br>    host_project_id   = "my-core-project-id"<br>  }<br>}</pre> | `any` | n/a | yes |
-| region | GCP region for all the created subnetworks and for all the imported subnetworks. Set to null to use a default provider's region.<br><br>To add subnetworks with another region use a separate instance of this module (and specify `create_network=false` to avoid creating a duplicate network). | `string` | `null` | no |
+| <a name="input_allowed_ports"></a> [allowed\_ports](#input\_allowed\_ports) | A list of ports to pass for the `networks` entries that do not have their own `allowed_ports` attribute. For example ["22", "443"]. Can also include ranges, for example ["80", "8080-8999"]. Empty list means to allow all. | `list(string)` | `[]` | no |
+| <a name="input_allowed_protocol"></a> [allowed\_protocol](#input\_allowed\_protocol) | A protocol (TCP or UDP) to pass for the `networks` entries that do not have their own `allowed_protocol` attribute. | `string` | `"all"` | no |
+| <a name="input_networks"></a> [networks](#input\_networks) | Map of networks, a minimal example:<pre>{<br>  "my-vpc" = {<br>    name            = "my-vpc"<br>    subnetwork_name = "my-subnet"<br>    ip_cidr_range   = "192.168.1.0/24"<br>  }<br>}</pre>An advanced example:<pre>{<br>  "my-vpc" = {<br>    name            = "my-vpc"<br>    subnetwork_name = "my-subnet"<br>    ip_cidr_range   = "192.168.1.0/24"<br>    allowed_sources = ["209.85.152.0/22"]<br>    log_metadata    = "INCLUDE_ALL_METADATA"<br>  }<br>}</pre>Full example:<pre>{<br>  "my-vpc" = {<br>    name             = "my-vpc"<br>    subnetwork_name  = "my-subnet"<br>    ip_cidr_range    = "192.168.1.0/24"<br>    allowed_sources  = ["10.0.0.0/8", "98.98.98.0/28"]<br>    allowed_protocol = "UDP"<br>    allowed_ports    = ["53", "123-125"]<br>    log_metadata     = "EXCLUDE_ALL_METADATA"<br><br>    delete_default_routes_on_create = true<br>  }<br>  "imported-from-hostproject" = {<br>    name              = "existing-core-vpc"<br>    subnetwork_name   = "existing-subnet"<br>    create_network    = false<br>    create_subnetwork = false<br>    host_project_id   = "my-core-project-id"<br>  }<br>}</pre> | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | GCP region for all the created subnetworks and for all the imported subnetworks. Set to null to use a default provider's region.<br><br>To add subnetworks with another region use a separate instance of this module (and specify `create_network=false` to avoid creating a duplicate network). | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| networks | n/a |
-| subnetworks | n/a |
-
+| <a name="output_networks"></a> [networks](#output\_networks) | n/a |
+| <a name="output_subnetworks"></a> [subnetworks](#output\_subnetworks) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description

Upgrade our documentation with terraform-docs v0.12

## Motivation and Context

Documentation unification, easier maintenance.

## How Has This Been Tested?

This has been tested by running the pre-commit webhook with terraform-docs v0.12.1

## Attention!

Please upgrade terraform-docs to version v0.12.1 - the new version supports the automatic creation of new sections in the documentation (like "Modules" and "Resources") and introduces a slightly different syntax when auto-generating documentation data.