### PR TITLE
TERRAM-57: (dockerfile): bump terraform-docs version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN curl -sL https://github.com/tfsec/tfsec/releases/download/v0.34.0/tfsec-linu
     mv tfsec /usr/local/bin/    && \
     echo "Newest release: $(curl -s https://api.github.com/repos/tfsec/tfsec/releases/latest | grep -o -E "https://.+?tfsec-linux-amd64")"
 
-RUN curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.10.1/terraform-docs-v0.10.1-linux-amd64 > terraform-docs    && \
+RUN curl -sL https://github.com/terraform-docs/terraform-docs/releases/download/v0.12.1/terraform-docs-v0.12.1-linux-amd64 > terraform-docs    && \
     chmod +x terraform-docs    && \
     mv terraform-docs /usr/local/bin/    && \
     echo "Newest release: $(curl -s https://api.github.com/repos/terraform-docs/terraform-docs/releases/latest | grep -o -E "https://.+?-linux-amd64")"


### PR DESCRIPTION
## Description

Update terraform-docs version in the CI.

## Motivation and Context

Use newer version of terraform-docs in our CI pipeline - which currently uses v0.10.

Changes in [PR57](https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules/pull/58) depend on this change to pass the CI.

## How Has This Been Tested?

Build the docker image with the updated Dockerfile.
