### PR TITLE
feat(examples): VM-Series standalone with metadata bootstrap

### DIFF
--- a/examples/standalone_vmseries_with_metadata_bootstrap/README.md
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/README.md
@@ -1,0 +1,45 @@
+# Palo Alto Networks VM-Series NGFW Module Example
+
+A Terraform module example for deploying a VM-Series NGFW in GCP using the [metadata](https://docs.paloaltonetworks.com/vm-series/10-2/vm-series-deployment/bootstrap-the-vm-series-firewall/choose-a-bootstrap-method#idf6412176-e973-488e-9d7a-c568fe1e33a9) bootstrap method.
+
+This example can be used to familarize oneself with both the VM-Series NGFW and Terraform - it creates a single instance of virtualized firewall in a Security VPC with a management-only interface and lacks any traffic inspection.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_management_vpc"></a> [management\_vpc](#module\_management\_vpc) | ../../modules/vpc | n/a |
+| <a name="module_vmseries"></a> [vmseries](#module\_vmseries) | ../../modules/vmseries | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allowed_sources"></a> [allowed\_sources](#input\_allowed\_sources) | n/a | `any` | n/a | yes |
+| <a name="input_bootstrap_options"></a> [bootstrap\_options](#input\_bootstrap\_options) | n/a | `any` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `any` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | n/a | `any` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_ssh_keys"></a> [ssh\_keys](#input\_ssh\_keys) | n/a | `any` | n/a | yes |
+| <a name="input_vmseries_image"></a> [vmseries\_image](#input\_vmseries\_image) | n/a | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_vmseries_address"></a> [vmseries\_address](#output\_vmseries\_address) | n/a |
+| <a name="output_vmseries_ssh_command"></a> [vmseries\_ssh\_command](#output\_vmseries\_ssh\_command) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/standalone_vmseries_with_metadata_bootstrap/example.tfvars
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/example.tfvars
@@ -1,0 +1,12 @@
+project         = "example"
+region          = "us-central1"
+name            = "example-vmseries"
+allowed_sources = "<list of IP CIDRs>"
+ssh_keys        = "admin:<public key>"
+vmseries_image  = "vmseries-flex-byol-1020"
+bootstrap_options = {
+  hostname           = "vms01"
+  panorama-server    = "10.1.2.3"
+  plugin-op-commands = "numa-perf-optimize:enable,set-dp-cores:2"
+  type               = "dhcp-client"
+}

--- a/examples/standalone_vmseries_with_metadata_bootstrap/main.tf
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/main.tf
@@ -1,0 +1,31 @@
+module "management_vpc" {
+  source = "../../modules/vpc"
+
+  networks = [
+    {
+      name            = "example-mgmt"
+      subnetwork_name = "example-mgmt"
+      ip_cidr_range   = "10.236.64.0/28"
+      allowed_sources = var.allowed_sources
+    }
+  ]
+}
+
+module "vmseries" {
+  source = "../../modules/vmseries"
+
+  name = "example-vmseries"
+  zone = "us-central1-a"
+
+  ssh_keys       = var.ssh_keys
+  vmseries_image = var.vmseries_image
+
+  bootstrap_options = var.bootstrap_options
+
+  network_interfaces = [
+    {
+      subnetwork       = module.management_vpc.subnetworks["example-mgmt"].self_link
+      create_public_ip = true
+    },
+  ]
+}

--- a/examples/standalone_vmseries_with_metadata_bootstrap/outputs.tf
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/outputs.tf
@@ -1,0 +1,7 @@
+output "vmseries_address" {
+  value = module.vmseries.public_ips[0]
+}
+
+output "vmseries_ssh_command" {
+  value = "ssh admin@${module.vmseries.public_ips[0]}"
+}

--- a/examples/standalone_vmseries_with_metadata_bootstrap/variables.tf
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/variables.tf
@@ -1,0 +1,7 @@
+variable "project" {}
+variable "region" {}
+variable "name" {}
+variable "allowed_sources" {}
+variable "ssh_keys" {}
+variable "vmseries_image" {}
+variable "bootstrap_options" {}

--- a/examples/standalone_vmseries_with_metadata_bootstrap/versions.tf
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/versions.tf
@@ -1,0 +1,4 @@
+provider "google" {
+  project = var.project
+  region  = var.region
+}

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_instance" "this" {
 
   boot_disk {
     initialize_params {
-      image = coalesce(var.custom_image, data.google_compute_image.vmseries[0].self_link)
+      image = coalesce(var.custom_image, try(data.google_compute_image.vmseries[0].self_link, null))
       type  = var.disk_type
     }
   }


### PR DESCRIPTION
## Description

New example covering simple bootstrap using GCP metadata.

Additionaly, one fix for use of a custom image in vmseries module, discovered when testing this example, has been incorporated.

## Motivation and Context

resolves #71 

## How Has This Been Tested?

Deploy and verify if all specified bootstrap options are properly configured.

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
