### PR TITLE
Upgrade provider versions for Mac M1 machines

### DIFF
--- a/examples/autoscale/versions.tf
+++ b/examples/autoscale/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.15.3, < 2.0"
 
   required_providers {
-    null   = { version = "~> 2.1" }
-    random = { version = "~> 2.3" }
+    null   = { version = "~> 3.1" }
+    random = { version = "~> 3.1" }
     google = { version = "~> 3.48" }
   }
 }

--- a/examples/lb_http_ext_global/versions.tf
+++ b/examples/lb_http_ext_global/versions.tf
@@ -2,8 +2,8 @@ terraform {
   required_version = ">= 0.15.3, < 2.0"
 
   required_providers {
-    null   = { version = "~> 2.1" }
-    random = { version = "~> 2.3" }
+    null   = { version = "~> 3.1" }
+    random = { version = "~> 3.1" }
     google = { version = "~> 3.48" }
   }
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,8 +1,8 @@
 terraform {
   required_version = ">= 0.15.3, < 2.0"
   required_providers {
-    null   = { version = "~> 2.1" }
-    random = { version = "~> 2.3" }
+    null   = { version = "~> 3.1" }
+    random = { version = "~> 3.1" }
     google = { version = "~> 3.30" }
     # google = { version = "~> 3.38" }  # because uniform_bucket_level_access
   }

--- a/modules/vmseries/versions.tf
+++ b/modules/vmseries/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.15.3, < 2.0"
 
   required_providers {
-    null   = { version = "~> 2.1" }
+    null   = { version = "~> 3.1" }
     google = { version = "~> 3.30" }
   }
 }


### PR DESCRIPTION
## Describe the bug

Mac M1-based machines require null and random providers to be minimum v3.1

## Expected behavior

Able to use modules on Mac M1-based machines

## Current behavior

Mac M1-based machines fail to use modules with older versions of the null and random providers

## Possible solution

Increase version numbers in versions.tf for the modules (and examples ideally)

## Steps to reproduce

Use modules on a Mac M1-based machine

## Your Environment

Terraform v1.1.9 on darwin_arm64
macOS 12.4