### PR TITLE
fix(modules/autoscale,bootstrap): remove provider versioning

### DIFF
--- a/modules/autoscale/README.md
+++ b/modules/autoscale/README.md
@@ -7,15 +7,13 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.3, < 2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.48 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 2.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 3.48 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 2.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 

--- a/modules/autoscale/main.tf
+++ b/modules/autoscale/main.tf
@@ -1,17 +1,3 @@
-terraform {
-  required_providers {
-    null = {
-      version = "~> 2.1"
-    }
-    random = {
-      version = "~> 2.3"
-    }
-    google = {
-      version = "~> 3.48"
-    }
-  }
-}
-
 resource "google_compute_instance_template" "this" {
   name_prefix      = var.prefix
   machine_type     = var.machine_type

--- a/modules/autoscale/versions.tf
+++ b/modules/autoscale/versions.tf
@@ -1,12 +1,6 @@
 terraform {
   required_version = ">= 0.15.3, < 2.0"
   required_providers {
-    null = {
-      version = "~> 2.1"
-    }
-    random = {
-      version = "~> 2.3"
-    }
     google = {
       version = "~> 3.48"
     }

--- a/modules/autoscale/versions.tf
+++ b/modules/autoscale/versions.tf
@@ -1,3 +1,14 @@
 terraform {
   required_version = ">= 0.15.3, < 2.0"
+  required_providers {
+    null = {
+      version = "~> 2.1"
+    }
+    random = {
+      version = "~> 2.3"
+    }
+    google = {
+      version = "~> 3.48"
+    }
+  }
 }

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -7,16 +7,13 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.3, < 2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -33,7 +30,6 @@ No modules.
 | [google_storage_bucket_object.file](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.license_empty](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.software_empty](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
-| [null_resource.dependency_setter](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_string.randomstring](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [google_compute_default_service_account.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 
@@ -51,5 +47,4 @@ No modules.
 |------|-------------|
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | n/a |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | n/a |
-| <a name="output_completion"></a> [completion](#output\_completion) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -50,17 +50,6 @@ resource "google_storage_bucket_object" "software_empty" {
   bucket  = google_storage_bucket.this.name
 }
 
-resource "null_resource" "dependency_setter" {
-  depends_on = [
-    google_storage_bucket.this,
-    google_storage_bucket_object.file,
-    google_storage_bucket_object.config_empty,
-    google_storage_bucket_object.content_empty,
-    google_storage_bucket_object.license_empty,
-    google_storage_bucket_object.software_empty,
-  ]
-}
-
 data "google_compute_default_service_account" "this" {}
 
 resource "google_storage_bucket_iam_member" "member" {

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -1,7 +1,3 @@
-output "completion" {
-  value = null_resource.dependency_setter.id
-}
-
 output "bucket_name" {
   value = google_storage_bucket.this.name
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,9 +1,6 @@
 terraform {
   required_version = ">= 0.15.3, < 2.0"
   required_providers {
-    null   = { version = "~> 3.1" }
-    random = { version = "~> 3.1" }
     google = { version = "~> 3.30" }
-    # google = { version = "~> 3.38" }  # because uniform_bucket_level_access
   }
 }


### PR DESCRIPTION
## Description

1. Removed `null` and `random` providers from bootstrap and autoscale modules.   
2. In modules/bootstrap, removed `"null_resource" "dependency_setter"` from main.tf and removed  `completion` output in outputs.tf

## Motivation and Context

1. The declaration of the `null` and `random` providers in the autoscale and bootstrap modules cause provider versioning collisions.  Neither of hte providers need to be declared in the modules themselves. 
2. The  `"null_resource" "dependency_setter"` in modules/bootstrap/main.tf is no longer necessary because Terraform v1.0 supports depends_on for modules.  The corresponding `completion` output in modules/bootstrap/outputs.tf has also been removed. 

## How Has This Been Tested?

The Terraform builds in /examples have been tested using the updated modules. 

## Screenshots (if appropriate)

N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
