### PR TITLE
docs: fix issues/releases links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ Contributions are welcome across the entire project:
 
 ### New Contributors
 
-1. Search the [issues](https://github.com/PaloAltoNetworks/terraform-ibm-vmseries-modules.git/issues) to see if there is an existing issue. If not, open an issue (note the issue ID).
+1. Search the [issues](https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules.git/issues) to see if there is an existing issue. If not, please open one.
 
-1. Fork the repository to your personal namespace (only need to do this once).
+1. Fork the repository to your personal namespace (only needed to do this once).
 
 1. Clone the repo from your personal namespace.
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ We are maintaining a [public roadmap](https://github.com/orgs/PaloAltoNetworks/p
 ## Versioning
 
 These modules follow the principles of [Semantic Versioning](http://semver.org/). You can find each new release,
-along with the changelog, on the GitHub [Releases](../../releases) page.
+along with the changelog, on the GitHub [Releases](https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules/releases) page.
 
 ## Getting Help
 
-[Open an issue](../../issues) on Github.
+[Open an issue](https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules/issues) on Github.
 
 ## Contributing
 


### PR DESCRIPTION
## Description

Fix links for issues/releases to link directly to Github.

## Motivation and Context

Relative links do not work properly with Terraform Registry.

## How Has This Been Tested?

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
