### PR TITLE
fix(examples/hub_spoke_common): added dedicated service account to vm-series instances

### DIFF
--- a/examples/hub_spoke_common/main.tf
+++ b/examples/hub_spoke_common/main.tf
@@ -166,6 +166,8 @@ module "vmseries" {
     serial-port-enable                   = true
   }
 
+  service_account = module.iam_service_account.email
+
   network_interfaces = [
     {
       subnetwork       = module.vpc_untrust.subnets_self_links[0]


### PR DESCRIPTION
## Description

Added service account to VM-Series instances
<!--- Describe your changes in detail -->

## Motivation and Context

Currently, the VM-Series deploys using the default service account which doesn't always have the permissions required for the VM-Series, this changes it to use the create IAM service account with the appropriate permissions.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

I have tested deployed this with a Default Service account with no permissions, and it bootstraped OK.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
