### PR TITLE
feat(modules/vpc): Added input key based outputs with networks and subnets

### DIFF
--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -53,5 +53,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_networks"></a> [networks](#output\_networks) | n/a |
+| <a name="output_networks_by_key"></a> [networks\_by\_key](#output\_networks\_by\_key) | Map with network objects corresponding to input keys (or index if list was provided) of `networks` variable. |
 | <a name="output_subnetworks"></a> [subnetworks](#output\_subnetworks) | n/a |
+| <a name="output_subnetworks_by_key"></a> [subnetworks\_by\_key](#output\_subnetworks\_by\_key) | Map with subnetwork objects corresponding to input key (or index if list was provided) of `networks` variable. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -1,11 +1,25 @@
+output "networks" {
+  value = { for _, v in var.networks : v.name
+    => try(data.google_compute_network.this[v.name], google_compute_network.this[v.name], null)
+  }
+}
+
 output "subnetworks" {
   value = { for _, v in var.networks : v.subnetwork_name
     => try(data.google_compute_subnetwork.this[v.subnetwork_name], google_compute_subnetwork.this[v.subnetwork_name], null)
   }
 }
 
-output "networks" {
-  value = { for _, v in var.networks : v.name
-    => try(data.google_compute_network.this[v.name], google_compute_network.this[v.name], null)
+output "networks_by_key" {
+  description = "Map with network objects corresponding to input keys (or index if list was provided) of `networks` variable."
+  value = { for k, v in var.networks :
+    k => try(data.google_compute_network.this[v.name], google_compute_network.this[v.name])
+  }
+}
+
+output "subnetworks_by_key" {
+  description = "Map with subnetwork objects corresponding to input key (or index if list was provided) of `networks` variable."
+  value = { for k, v in var.networks :
+    k => try(data.google_compute_subnetwork.this[v.subnetwork_name], google_compute_subnetwork.this[v.subnetwork_name])
   }
 }


### PR DESCRIPTION
## Description

New outputs with network/subnet data organized by `var.networks` input keys (indicies in case when list is provided).

## Motivation and Context

Allow to refer a network/subnet by input key (index), 

## How Has This Been Tested?

Apply simple example with vpc module invocation with a map and a list of netowrks to be created.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
