### PR TITLE
131 missing project in vmseries

### DIFF
--- a/examples/hub_spoke_common/main.tf
+++ b/examples/hub_spoke_common/main.tf
@@ -369,7 +369,7 @@ resource "google_compute_instance_group" "spoke1_ig" {
   name = "${local.prefix}spoke1-ig"
   zone = data.google_compute_zones.main.names[0]
 
-  instances = google_compute_instance.spoke1_vm.*.id
+  instances = [google_compute_instance.spoke1_vm.*.id]
 }
 
 module "spoke1_ilb" {

--- a/examples/lb_http_ext_global/verify.tf
+++ b/examples/lb_http_ext_global/verify.tf
@@ -37,7 +37,7 @@ resource "null_resource" "verify_with_curl" {
   }
 
   triggers = {
-    run_me_every_time = "${timestamp()}"
+    run_me_every_time = timestamp()
   }
 
   depends_on = [null_resource.delay_actual_use]

--- a/modules/lb_http_ext_global/main.tf
+++ b/modules/lb_http_ext_global/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_target_https_proxy" "default" {
   count            = var.ssl ? 1 : 0
   name             = "${var.name}-https-proxy"
   url_map          = (var.url_map != null ? var.url_map : google_compute_url_map.default.self_link)
-  ssl_certificates = compact(concat(var.ssl_certificates, google_compute_ssl_certificate.default.*.self_link, ), )
+  ssl_certificates = compact(concat(var.ssl_certificates, [google_compute_ssl_certificate.default.*.self_link], ), )
 }
 
 resource "google_compute_ssl_certificate" "default" {

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -15,12 +15,12 @@ data "google_compute_image" "vmseries" {
   count = var.custom_image == null ? 1 : 0
 
   name    = var.vmseries_image
-  project = "paloaltonetworksgcp-public"
+  project = var.project
 }
 
 data "google_compute_subnetwork" "this" {
-  for_each = { for k, v in var.network_interfaces : k => v }
-
+  for_each  = { for k, v in var.network_interfaces : k => v }
+  project   = var.project
   self_link = each.value.subnetwork
 }
 
@@ -36,6 +36,7 @@ resource "google_compute_address" "private" {
   name         = try(each.value.private_ip_name, "${var.name}-${each.key}-private")
   address_type = "INTERNAL"
   address      = try(each.value.private_ip, null)
+  project      = var.project
   subnetwork   = each.value.subnetwork
   region       = data.google_compute_subnetwork.this[each.key].region
 }
@@ -45,6 +46,7 @@ resource "google_compute_address" "public" {
 
   name         = try(each.value.public_ip_name, "${var.name}-${each.key}-public")
   address_type = "EXTERNAL"
+  project      = var.project
   region       = data.google_compute_subnetwork.this[each.key].region
 }
 

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -15,7 +15,7 @@ data "google_compute_image" "vmseries" {
   count = var.custom_image == null ? 1 : 0
 
   name    = var.vmseries_image
-  project = var.project
+  project = "paloaltonetworksgcp-public"
 }
 
 data "google_compute_subnetwork" "this" {


### PR DESCRIPTION
## Description

1. Adding the project parameter to the following resources in modules/vmseries/main.tf:

data "google_compute_subnetwork" "this" on line 18
resource "google_compute_address" "private" on line 24
resource "google_compute_address" "public" on line 30

1. Fixing the warnings generated by the pre-commit hooks.

## Motivation and Context

When deploying the vmseries module through a Jenkins pipeline, the deployment fails with "Cross-project references for this resource are not allowed". 

## How Has This Been Tested?

These changes have been made to the local copy of the repo in our environment, and vmseries firewalls were successfully deployed where they had previously failed.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
