### PR TITLE
fix(modules/lb_external): use of existing external address

### DIFF
--- a/modules/lb_external/main.tf
+++ b/modules/lb_external/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_forwarding_rule" "rule" {
   #   If false set value to the value of `port_range`. If `port_range` isn't specified, then set the value to `null`.
   port_range = lookup(each.value, "ip_protocol", "TCP") == "L3_DEFAULT" ? null : lookup(each.value, "port_range", null)
 
-  ip_address  = lookup(each.value, "ip_address", google_compute_address.this[each.key].address)
+  ip_address  = try(each.value.ip_address, google_compute_address.this[each.key].address)
   ip_protocol = lookup(each.value, "ip_protocol", "TCP")
 }
 


### PR DESCRIPTION
## Description

Fix for existing external IP assignment to a forwarding rule.

## Motivation and Context

Currently if an existing external IP is provided in rule configuration plan fails with a message as below:
```│ Error: Invalid index
│ 
│   on .terraform/modules/lb_external/modules/lb_external/main.tf line 56, in resource "google_compute_forwarding_rule" "rule":
│   56:   ip_address  = lookup(each.value, "ip_address", google_compute_address.this[each.key].address)
│     ├────────────────
│     │ each.key is "static-ip-service"
│     │ google_compute_address.this is object with 2 attributes
│ 
│ The given key does not identify an element in this collection value.
```

## How Has This Been Tested?

Apply configuration with rules covering both existing and dynamically assigned at apply.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
