### PR TITLE
feat(modules): Added new vpc-peering module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           # Semantic version range syntax (like 3.x) or the exact Python version
-          python-version: "3.9.4"
+          python-version: "3.11.0"
 
       - name: Run pre-commit framework as the developer should run it
         run: sudo ./scripts/install.sh && sudo ./scripts/run.sh

--- a/modules/vpc-peering/README.md
+++ b/modules/vpc-peering/README.md
@@ -1,0 +1,50 @@
+# VPC peering
+
+The module allows to create VPC peering between two networks in both directions.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.3, < 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_network_peering.local](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering) | resource |
+| [google_compute_network_peering.peer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_local_export_custom_routes"></a> [local\_export\_custom\_routes](#input\_local\_export\_custom\_routes) | Export custom routes setting for 'local->peer' direction. | `bool` | `false` | no |
+| <a name="input_local_export_subnet_routes_with_public_ip"></a> [local\_export\_subnet\_routes\_with\_public\_ip](#input\_local\_export\_subnet\_routes\_with\_public\_ip) | Export subnet routes with public IP setting for 'local->peer' direction. | `bool` | `true` | no |
+| <a name="input_local_import_custom_routes"></a> [local\_import\_custom\_routes](#input\_local\_import\_custom\_routes) | Import custom routes setting for 'local->peer' direction. | `bool` | `false` | no |
+| <a name="input_local_import_subnet_routes_with_public_ip"></a> [local\_import\_subnet\_routes\_with\_public\_ip](#input\_local\_import\_subnet\_routes\_with\_public\_ip) | Import subnet routes with public IP setting for 'local->peer' direction. | `bool` | `false` | no |
+| <a name="input_local_network"></a> [local\_network](#input\_local\_network) | Self-link or id of the first network (local) in pair. | `string` | n/a | yes |
+| <a name="input_local_peering_name"></a> [local\_peering\_name](#input\_local\_peering\_name) | Name for 'local->peer' direction peering resource. If not specified defaults to `<name_prefix><local network name>-<peer network name>`. | `string` | `null` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Optional prefix for auto-generated peering resource names. | `string` | `""` | no |
+| <a name="input_peer_export_custom_routes"></a> [peer\_export\_custom\_routes](#input\_peer\_export\_custom\_routes) | Export custom routes setting for 'peer->local' direction. | `bool` | `false` | no |
+| <a name="input_peer_export_subnet_routes_with_public_ip"></a> [peer\_export\_subnet\_routes\_with\_public\_ip](#input\_peer\_export\_subnet\_routes\_with\_public\_ip) | Export subnet routes with public IP setting for 'peer->local' direction. | `bool` | `true` | no |
+| <a name="input_peer_import_custom_routes"></a> [peer\_import\_custom\_routes](#input\_peer\_import\_custom\_routes) | Import custom routes setting for 'peer->local' direction. | `bool` | `false` | no |
+| <a name="input_peer_import_subnet_routes_with_public_ip"></a> [peer\_import\_subnet\_routes\_with\_public\_ip](#input\_peer\_import\_subnet\_routes\_with\_public\_ip) | Import subnet routes with public IP setting for 'peer->local' direction. | `bool` | `false` | no |
+| <a name="input_peer_network"></a> [peer\_network](#input\_peer\_network) | Self-link or id of the second network (peer) in pair. | `string` | n/a | yes |
+| <a name="input_peer_peering_name"></a> [peer\_peering\_name](#input\_peer\_peering\_name) | Name for 'peer->local' direction peering resource. If not specified defaults to `<name_prefix><peer network name>-<local network name>`. | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/vpc-peering/README.md
+++ b/modules/vpc-peering/README.md
@@ -2,6 +2,8 @@
 
 The module allows to create VPC peering between two networks in both directions.
 
+By default, no routes are exported/imported for each direction, every option has to be explicitely enabled by setting appropriate value to `true`.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
@@ -31,14 +33,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_local_export_custom_routes"></a> [local\_export\_custom\_routes](#input\_local\_export\_custom\_routes) | Export custom routes setting for 'local->peer' direction. | `bool` | `false` | no |
-| <a name="input_local_export_subnet_routes_with_public_ip"></a> [local\_export\_subnet\_routes\_with\_public\_ip](#input\_local\_export\_subnet\_routes\_with\_public\_ip) | Export subnet routes with public IP setting for 'local->peer' direction. | `bool` | `true` | no |
+| <a name="input_local_export_subnet_routes_with_public_ip"></a> [local\_export\_subnet\_routes\_with\_public\_ip](#input\_local\_export\_subnet\_routes\_with\_public\_ip) | Export subnet routes with public IP setting for 'local->peer' direction. | `bool` | `false` | no |
 | <a name="input_local_import_custom_routes"></a> [local\_import\_custom\_routes](#input\_local\_import\_custom\_routes) | Import custom routes setting for 'local->peer' direction. | `bool` | `false` | no |
 | <a name="input_local_import_subnet_routes_with_public_ip"></a> [local\_import\_subnet\_routes\_with\_public\_ip](#input\_local\_import\_subnet\_routes\_with\_public\_ip) | Import subnet routes with public IP setting for 'local->peer' direction. | `bool` | `false` | no |
 | <a name="input_local_network"></a> [local\_network](#input\_local\_network) | Self-link or id of the first network (local) in pair. | `string` | n/a | yes |
 | <a name="input_local_peering_name"></a> [local\_peering\_name](#input\_local\_peering\_name) | Name for 'local->peer' direction peering resource. If not specified defaults to `<name_prefix><local network name>-<peer network name>`. | `string` | `null` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Optional prefix for auto-generated peering resource names. | `string` | `""` | no |
 | <a name="input_peer_export_custom_routes"></a> [peer\_export\_custom\_routes](#input\_peer\_export\_custom\_routes) | Export custom routes setting for 'peer->local' direction. | `bool` | `false` | no |
-| <a name="input_peer_export_subnet_routes_with_public_ip"></a> [peer\_export\_subnet\_routes\_with\_public\_ip](#input\_peer\_export\_subnet\_routes\_with\_public\_ip) | Export subnet routes with public IP setting for 'peer->local' direction. | `bool` | `true` | no |
+| <a name="input_peer_export_subnet_routes_with_public_ip"></a> [peer\_export\_subnet\_routes\_with\_public\_ip](#input\_peer\_export\_subnet\_routes\_with\_public\_ip) | Export subnet routes with public IP setting for 'peer->local' direction. | `bool` | `false` | no |
 | <a name="input_peer_import_custom_routes"></a> [peer\_import\_custom\_routes](#input\_peer\_import\_custom\_routes) | Import custom routes setting for 'peer->local' direction. | `bool` | `false` | no |
 | <a name="input_peer_import_subnet_routes_with_public_ip"></a> [peer\_import\_subnet\_routes\_with\_public\_ip](#input\_peer\_import\_subnet\_routes\_with\_public\_ip) | Import subnet routes with public IP setting for 'peer->local' direction. | `bool` | `false` | no |
 | <a name="input_peer_network"></a> [peer\_network](#input\_peer\_network) | Self-link or id of the second network (peer) in pair. | `string` | n/a | yes |

--- a/modules/vpc-peering/main.tf
+++ b/modules/vpc-peering/main.tf
@@ -1,0 +1,28 @@
+locals {
+  local_network_name = reverse(split("/", var.local_network))[0]
+  peer_network_name  = reverse(split("/", var.peer_network))[0]
+}
+
+resource "google_compute_network_peering" "local" {
+  name         = coalesce(var.local_peering_name, "${var.name_prefix}${local.local_network_name}-${local.peer_network_name}")
+  network      = var.local_network
+  peer_network = var.peer_network
+
+  export_custom_routes = var.local_export_custom_routes
+  import_custom_routes = var.local_import_custom_routes
+
+  export_subnet_routes_with_public_ip = var.local_export_subnet_routes_with_public_ip
+  import_subnet_routes_with_public_ip = var.local_import_subnet_routes_with_public_ip
+}
+
+resource "google_compute_network_peering" "peer" {
+  name         = coalesce(var.peer_peering_name, "${var.name_prefix}${local.peer_network_name}-${local.local_network_name}")
+  network      = var.peer_network
+  peer_network = var.local_network
+
+  export_custom_routes = var.peer_export_custom_routes
+  import_custom_routes = var.peer_import_custom_routes
+
+  export_subnet_routes_with_public_ip = var.peer_export_subnet_routes_with_public_ip
+  import_subnet_routes_with_public_ip = var.peer_import_subnet_routes_with_public_ip
+}

--- a/modules/vpc-peering/variables.tf
+++ b/modules/vpc-peering/variables.tf
@@ -40,7 +40,7 @@ variable "local_import_custom_routes" {
 
 variable "local_export_subnet_routes_with_public_ip" {
   description = "Export subnet routes with public IP setting for 'local->peer' direction."
-  default     = true
+  default     = false
   type        = bool
 }
 
@@ -64,7 +64,7 @@ variable "peer_import_custom_routes" {
 
 variable "peer_export_subnet_routes_with_public_ip" {
   description = "Export subnet routes with public IP setting for 'peer->local' direction."
-  default     = true
+  default     = false
   type        = bool
 }
 

--- a/modules/vpc-peering/variables.tf
+++ b/modules/vpc-peering/variables.tf
@@ -1,0 +1,75 @@
+variable "local_network" {
+  description = "Self-link or id of the first network (local) in pair."
+  type        = string
+}
+
+variable "peer_network" {
+  description = "Self-link or id of the second network (peer) in pair."
+  type        = string
+}
+
+variable "local_peering_name" {
+  description = "Name for 'local->peer' direction peering resource. If not specified defaults to `<name_prefix><local network name>-<peer network name>`."
+  default     = null
+  type        = string
+}
+
+variable "peer_peering_name" {
+  description = "Name for 'peer->local' direction peering resource. If not specified defaults to `<name_prefix><peer network name>-<local network name>`."
+  default     = null
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Optional prefix for auto-generated peering resource names."
+  default     = ""
+  type        = string
+}
+
+variable "local_export_custom_routes" {
+  description = "Export custom routes setting for 'local->peer' direction."
+  default     = false
+  type        = bool
+}
+
+variable "local_import_custom_routes" {
+  description = "Import custom routes setting for 'local->peer' direction."
+  default     = false
+  type        = bool
+}
+
+variable "local_export_subnet_routes_with_public_ip" {
+  description = "Export subnet routes with public IP setting for 'local->peer' direction."
+  default     = true
+  type        = bool
+}
+
+variable "local_import_subnet_routes_with_public_ip" {
+  description = "Import subnet routes with public IP setting for 'local->peer' direction."
+  default     = false
+  type        = bool
+}
+
+variable "peer_export_custom_routes" {
+  description = "Export custom routes setting for 'peer->local' direction."
+  default     = false
+  type        = bool
+}
+
+variable "peer_import_custom_routes" {
+  description = "Import custom routes setting for 'peer->local' direction."
+  default     = false
+  type        = bool
+}
+
+variable "peer_export_subnet_routes_with_public_ip" {
+  description = "Export subnet routes with public IP setting for 'peer->local' direction."
+  default     = true
+  type        = bool
+}
+
+variable "peer_import_subnet_routes_with_public_ip" {
+  description = "Import subnet routes with public IP setting for 'peer->local' direction."
+  default     = false
+  type        = bool
+}

--- a/modules/vpc-peering/versions.tf
+++ b/modules/vpc-peering/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.15.3, < 2.0"
+}


### PR DESCRIPTION
## Description

New module that allows to create bi-directional peerings between VPCs.

## Motivation and Context

VPC peering is an important building block used in standard designs of VM-Series deployments in GCP.

## How Has This Been Tested?

Use module instead of peering resources in common firewall example, utilizing different input values.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
