### PR TITLE
Add location for GCS bucket as input variable of module "bootstrap".

### DIFF
--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -8,6 +8,7 @@ resource "google_storage_bucket" "this" {
   name                        = join("", [var.name_prefix, random_string.randomstring.result])
   force_destroy               = true
   uniform_bucket_level_access = true
+  location                    = var.location
 }
 
 resource "google_storage_bucket_object" "file" {

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -15,3 +15,9 @@ variable "service_account" {
   default     = null
   type        = string
 }
+
+variable "location" {
+  description = "Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations."
+  default     = "us"
+  type        = string
+}


### PR DESCRIPTION
## Description

- `modules/bootstrap`
  - `maint.tf`
    - added argument `location = var.location` to resource `"google_storage_bucket" "this"`
  - `variables.tf`
    - added variable definition for `location`, with default value of `us` (GCS default value) and a description.

## Motivation and Context

Solving Issue #148

## How Has This Been Tested?

module/bootstrap has been tested by running examples/common_firewall. Build works as expected.
Also there is no change to the default behaviour, just and additional argument that can be used to change the location of the GCS Bucket from the default "us" to a custom one.

## Types of changes

<!--- What types of changes does your code introduce? -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
