### PR TITLE
feat(modules/bootstrap)!: Allow to specify GCS bucket location

### DIFF
--- a/examples/common_firewall/main.tf
+++ b/examples/common_firewall/main.tf
@@ -14,6 +14,7 @@ module "bootstrap" {
   source = "../../modules/bootstrap/"
 
   service_account = module.iam_service_account.email
+  location        = "us"
   files = {
     "bootstrap_files/init-cfg.txt" = "config/init-cfg.txt"
     "bootstrap_files/authcodes"    = "license/authcodes"

--- a/examples/hub_spoke_common/main.tf
+++ b/examples/hub_spoke_common/main.tf
@@ -143,6 +143,8 @@ module "bootstrap" {
   source = "../../modules/bootstrap/"
 
   service_account = module.iam_service_account.email
+  location        = "us"
+
   files = {
     "bootstrap_files/init-cfg.txt.sample"  = "config/init-cfg.txt"
     "bootstrap_files/bootstrap.xml.sample" = "config/bootstrap.xml"

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -38,6 +38,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_files"></a> [files](#input\_files) | Map of all files to copy to bucket. The keys are local paths, the values are remote paths. For example `{"dir/my.txt" = "config/init-cfg.txt"}` | `map(string)` | `{}` | no |
+| <a name="input_location"></a> [location](#input\_location) | Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations. | `string` | n/a | yes |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix of the name of Google Cloud Storage bucket, followed by 10 random characters | `string` | `"paloaltonetworks-firewall-bootstrap-"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Optional IAM Service Account (just an email) that will be granted read-only access to this bucket | `string` | `null` | no |
 

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -8,6 +8,7 @@ resource "google_storage_bucket" "this" {
   name                        = join("", [var.name_prefix, random_string.randomstring.result])
   force_destroy               = true
   uniform_bucket_level_access = true
+  location                    = var.location
 }
 
 resource "google_storage_bucket_object" "file" {

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -15,3 +15,9 @@ variable "service_account" {
   default     = null
   type        = string
 }
+
+variable "location" {
+  description = "Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations."
+  default     = "us"
+  type        = string
+}

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -18,6 +18,5 @@ variable "service_account" {
 
 variable "location" {
   description = "Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations."
-  default     = "us"
   type        = string
 }


### PR DESCRIPTION
## Description

- `modules/bootstrap`
  - `maint.tf`
    - added argument `location = var.location` to resource `"google_storage_bucket" "this"`
  - `variables.tf`
    - added variable definition for `location`, with default value of `us` (GCS default value) and a description.

## Motivation and Context

Solving Issue #148

## How Has This Been Tested?

module/bootstrap has been tested by running examples/common_firewall. Build works as expected.
Also there is no change to the default behaviour, just and additional argument that can be used to change the location of the GCS Bucket from the default "us" to a custom one.

## Types of changes

<!--- What types of changes does your code introduce? -->

- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.