### PR TITLE
feat(modules/lb_internal): Added connection tracking policy settings

### DIFF
--- a/modules/lb_internal/README.md
+++ b/modules/lb_internal/README.md
@@ -13,6 +13,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
 
 ## Modules
 
@@ -22,9 +23,9 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [google-beta_google_compute_region_backend_service.this](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_region_backend_service) | resource |
 | [google_compute_forwarding_rule.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_compute_health_check.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
-| [google_compute_region_backend_service.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_backend_service) | resource |
 | [google_client_config.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
 ## Inputs
@@ -35,6 +36,7 @@ No modules.
 | <a name="input_allow_global_access"></a> [allow\_global\_access](#input\_allow\_global\_access) | (Optional) If true, clients can access ILB from all regions. By default false, only allow from the ILB's local region; useful if the ILB is a next hop of a route. | `bool` | `false` | no |
 | <a name="input_backends"></a> [backends](#input\_backends) | Names of primary backend groups (IGs or IGMs). Typically use `module.vmseries.instance_group_self_links` here. | `map(string)` | n/a | yes |
 | <a name="input_connection_draining_timeout_sec"></a> [connection\_draining\_timeout\_sec](#input\_connection\_draining\_timeout\_sec) | (Optional) Time for which instance will be drained (not accept new connections, but still work to finish started). | `number` | `null` | no |
+| <a name="input_connection_tracking_policy"></a> [connection\_tracking\_policy](#input\_connection\_tracking\_policy) | Connection tracking policy settings. Following options are available:<br>- `mode`                              - (Optional\|string) `PER_CONNECTION` (default) or `PER_SESSION`<br>- `idle_timeout_sec`                  - (Optional\|number) Defaults to 600 seconds, can only be modified in specific conditions (see link below)<br>- `persistence_on_unhealthy_backends` - (Optional\|string) `DEFAULT_FOR_PROTOCOL` (default), `ALWAYS_PERSIST` or `NEVER_PERSIST`<br><br>More information about supported configurations in conjunction with `session_affinity` is available in [Internal TCP/UDP Load Balancing](https://cloud.google.com/load-balancing/docs/internal#connection-tracking) documentation. | `map(any)` | `null` | no |
 | <a name="input_disable_connection_drain_on_failover"></a> [disable\_connection\_drain\_on\_failover](#input\_disable\_connection\_drain\_on\_failover) | (Optional) On failover or failback, this field indicates whether connection drain will be honored. Setting this to true has the following effect: connections to the old active pool are not drained. Connections to the new active pool use the timeout of 10 min (currently fixed). Setting to false has the following effect: both old and new connections will have a drain timeout of 10 min. This can be set to true only if the protocol is TCP. The default is false. | `bool` | `null` | no |
 | <a name="input_drop_traffic_if_unhealthy"></a> [drop\_traffic\_if\_unhealthy](#input\_drop\_traffic\_if\_unhealthy) | (Optional) Used only when no healthy VMs are detected in the primary and backup instance groups. When set to true, traffic is dropped. When set to false, new connections are sent across all VMs in the primary group. The default is false. | `bool` | `null` | no |
 | <a name="input_failover_backends"></a> [failover\_backends](#input\_failover\_backends) | (Optional) Names of failover backend groups (IGs or IGMs). Failover groups are ignored unless the primary groups do not meet collective health threshold. | `map(string)` | `{}` | no |
@@ -47,7 +49,7 @@ No modules.
 | <a name="input_network"></a> [network](#input\_network) | n/a | `any` | `null` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | Which port numbers are forwarded to the backends (up to 5 ports). Conflicts with all\_ports. | `list(number)` | `[]` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region to create ILB in. | `string` | `null` | no |
-| <a name="input_session_affinity"></a> [session\_affinity](#input\_session\_affinity) | (Optional, TCP only) Try to direct sessions to the same backend, can be: CLIENT\_IP, CLIENT\_IP\_PORT\_PROTO, CLIENT\_IP\_PROTO, NONE (default is NONE). | `string` | `null` | no |
+| <a name="input_session_affinity"></a> [session\_affinity](#input\_session\_affinity) | Controls distribution of new connections (or fragmented UDP packets) from clients to the backends, can influence available connection tracking configurations.<br>Valid values are: NONE (default), CLIENT\_IP\_NO\_DESTINATION, CLIENT\_IP, CLIENT\_IP\_PROTO, CLIENT\_IP\_PORT\_PROTO. | `string` | `null` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | n/a | `string` | n/a | yes |
 | <a name="input_timeout_sec"></a> [timeout\_sec](#input\_timeout\_sec) | (Optional) How many seconds to wait for the backend before dropping the connection. Default is 30 seconds. Valid range is [1, 86400]. | `number` | `null` | no |
 

--- a/modules/lb_internal/variables.tf
+++ b/modules/lb_internal/variables.tf
@@ -63,11 +63,26 @@ variable "network" {
 }
 
 variable "session_affinity" {
-  description = "(Optional, TCP only) Try to direct sessions to the same backend, can be: CLIENT_IP, CLIENT_IP_PORT_PROTO, CLIENT_IP_PROTO, NONE (default is NONE)."
+  description = <<-EOF
+  Controls distribution of new connections (or fragmented UDP packets) from clients to the backends, can influence available connection tracking configurations.
+  Valid values are: NONE (default), CLIENT_IP_NO_DESTINATION, CLIENT_IP, CLIENT_IP_PROTO, CLIENT_IP_PORT_PROTO.
+  EOF
   default     = null
   type        = string
 }
 
+variable "connection_tracking_policy" {
+  description = <<-EOF
+  Connection tracking policy settings. Following options are available:
+  - `mode`                              - (Optional|string) `PER_CONNECTION` (default) or `PER_SESSION`
+  - `idle_timeout_sec`                  - (Optional|number) Defaults to 600 seconds, can only be modified in specific conditions (see link below)
+  - `persistence_on_unhealthy_backends` - (Optional|string) `DEFAULT_FOR_PROTOCOL` (default), `ALWAYS_PERSIST` or `NEVER_PERSIST`
+
+  More information about supported configurations in conjunction with `session_affinity` is available in [Internal TCP/UDP Load Balancing](https://cloud.google.com/load-balancing/docs/internal#connection-tracking) documentation.
+  EOF
+  default     = null
+  type        = map(any)
+}
 
 variable "timeout_sec" {
   description = "(Optional) How many seconds to wait for the backend before dropping the connection. Default is 30 seconds. Valid range is [1, 86400]."


### PR DESCRIPTION
## Description

Add support to configure connection tracking policy for internal load balancer.

## Motivation and Context

Resolved #160 

## How Has This Been Tested?

Apply common-firewall example with empty config, add a configuration, apply again.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
