### PR TITLE
feat(modules/lb_http_ext_global)!: Allow to customize healthcheck name and port

### DIFF
--- a/modules/lb_http_ext_global/README.md
+++ b/modules/lb_http_ext_global/README.md
@@ -74,6 +74,8 @@ No modules.
 | <a name="input_capacity_scaler"></a> [capacity\_scaler](#input\_capacity\_scaler) | n/a | `number` | `null` | no |
 | <a name="input_cdn"></a> [cdn](#input\_cdn) | Set to `true` to enable cdn on backend. | `bool` | `false` | no |
 | <a name="input_certificate"></a> [certificate](#input\_certificate) | Content of the SSL certificate. Required if `ssl` is `true` and `ssl_certificates` is empty. | `string` | `""` | no |
+| <a name="input_health_check_name"></a> [health\_check\_name](#input\_health\_check\_name) | Name for the health check. If not provided, defaults to `<var.name>-healthcheck`. | `string` | `null` | no |
+| <a name="input_health_check_port"></a> [health\_check\_port](#input\_health\_check\_port) | TCP port to use for health check. | `number` | `80` | no |
 | <a name="input_http_forward"></a> [http\_forward](#input\_http\_forward) | Set to `false` to disable HTTP port 80 forward | `bool` | `true` | no |
 | <a name="input_ip_version"></a> [ip\_version](#input\_ip\_version) | IP version for the Global address (IPv4 or v6) - Empty defaults to IPV4 | `string` | `""` | no |
 | <a name="input_max_connections_per_instance"></a> [max\_connections\_per\_instance](#input\_max\_connections\_per\_instance) | n/a | `number` | `null` | no |

--- a/modules/lb_http_ext_global/main.tf
+++ b/modules/lb_http_ext_global/main.tf
@@ -78,10 +78,8 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_health_check" "default" {
-  name = "${var.name}-check-0"
+  name = coalesce(var.health_check_name, "${var.name}-healthcheck")
   tcp_health_check {
-    port = "22"
+    port = var.health_check_port
   }
-  # request_path = split(",", var.backend_params[0])[0]
-  # port         = split(",", var.backend_params[0])[2]
 }

--- a/modules/lb_http_ext_global/variables.tf
+++ b/modules/lb_http_ext_global/variables.tf
@@ -27,6 +27,18 @@ variable "backend_protocol" {
   type        = string
 }
 
+variable "health_check_name" {
+  description = "Name for the health check. If not provided, defaults to `<var.name>-healthcheck`."
+  default     = null
+  type        = string
+}
+
+variable "health_check_port" {
+  description = "TCP port to use for health check."
+  default     = 80
+  type        = number
+}
+
 variable "timeout_sec" {
   description = "Timeout to consider a connection dead, in seconds (default 30)"
   default     = null


### PR DESCRIPTION
Allow to provide a custom health check name and port.

Additionally, change default port from 22 to 80 (breaking change, however using http or https is recommended over ssh) and default name used when custom one is not provided.

## Description

## Motivation and Context

Enhance module flexibility, provide default port based on recommendations.

## How Has This Been Tested?

Applied code that uses the module together with vmseries.

## Screenshots (if appropriate)

## Types of changes

- Breaking change (feature that would cause existing functionality to change)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
