### PR TITLE
feat(modules/bootstrap): Folder path support for bootstrap bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Terraform
         uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: 0.15.3
+          terraform_version: 1.0.0
 
       - name: terraform validate
         run: |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -38,7 +38,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_files"></a> [files](#input\_files) | Map of all files to copy to bucket. The keys are local paths, the values are remote paths. For example `{"dir/my.txt" = "config/init-cfg.txt"}` | `map(string)` | `{}` | no |
-| <a name="input_folders"></a> [folders](#input\_folders) | A list of folder paths that will impact where the bootstrap package(s) folders will be created in.<br>A default value (empty list) will cause the bootstrap package folders to be created in the bucket root directory. | `list(any)` | `[]` | no |
+| <a name="input_folders"></a> [folders](#input\_folders) | List of folder paths that will be used to create dedicated boostrap package folder sets per firewall or firewall group (for example to distinguish configuration per region, per inbound/obew role, etc) within the created storage bucket.<br><br>A default value (empty list) will result in the creation of a single bootstrap package folder set in the bucket top-level directory. | `list(any)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations. | `string` | n/a | yes |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix of the name of Google Cloud Storage bucket, followed by 10 random characters | `string` | `"paloaltonetworks-firewall-bootstrap-"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Optional IAM Service Account (just an email) that will be granted read-only access to this bucket | `string` | `null` | no |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.3, < 2.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0, < 2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
 
 ## Providers
@@ -38,6 +38,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_files"></a> [files](#input\_files) | Map of all files to copy to bucket. The keys are local paths, the values are remote paths. For example `{"dir/my.txt" = "config/init-cfg.txt"}` | `map(string)` | `{}` | no |
+| <a name="input_folders"></a> [folders](#input\_folders) | A list of folder paths that will impact where the bootstrap package(s) folders will be created in.<br>A default value (empty list) will cause the bootstrap package folders to be created in the bucket root directory. | `list(any)` | `[]` | no |
 | <a name="input_location"></a> [location](#input\_location) | Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations. | `string` | n/a | yes |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix of the name of Google Cloud Storage bucket, followed by 10 random characters | `string` | `"paloaltonetworks-firewall-bootstrap-"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Optional IAM Service Account (just an email) that will be granted read-only access to this bucket | `string` | `null` | no |

--- a/modules/bootstrap/README.md
+++ b/modules/bootstrap/README.md
@@ -6,13 +6,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0, < 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.54 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.30 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 4.54 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.30 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules

--- a/modules/bootstrap/main.tf
+++ b/modules/bootstrap/main.tf
@@ -15,44 +15,49 @@ resource "google_storage_bucket" "this" {
   }
 }
 
+locals {
+  folders = length(var.folders) == 0 ? [""] : var.folders
+}
+
+
+resource "google_storage_bucket_object" "config_empty" {
+  for_each = toset(local.folders)
+
+  name    = each.value != "" ? "${each.value}/config/" : "config/"
+  content = "config/"
+  bucket  = google_storage_bucket.this.name
+}
+
+resource "google_storage_bucket_object" "content_empty" {
+  for_each = toset(local.folders)
+
+  name    = each.value != "" ? "${each.value}/content/" : "content/"
+  content = "content/"
+  bucket  = google_storage_bucket.this.name
+}
+
+resource "google_storage_bucket_object" "license_empty" {
+  for_each = toset(local.folders)
+
+  name    = each.value != "" ? "${each.value}/license/" : "license/"
+  content = "license/"
+  bucket  = google_storage_bucket.this.name
+}
+
+resource "google_storage_bucket_object" "software_empty" {
+  for_each = toset(local.folders)
+
+  name    = each.value != "" ? "${each.value}/software/" : "software/"
+  content = "software/"
+  bucket  = google_storage_bucket.this.name
+}
+
 resource "google_storage_bucket_object" "file" {
   for_each = var.files
 
   name   = each.value
   source = each.key
   bucket = google_storage_bucket.this.name
-}
-
-resource "google_storage_bucket_object" "config_empty" {
-  count = contains([for f in values(var.files) : true if trimprefix(f, "config/") != f], true) ? 0 : 1
-
-  name    = "config/"
-  content = "config/"
-  bucket  = google_storage_bucket.this.name
-}
-
-resource "google_storage_bucket_object" "content_empty" {
-  count = contains([for f in values(var.files) : true if trimprefix(f, "content/") != f], true) ? 0 : 1
-
-  name    = "content/"
-  content = "content/"
-  bucket  = google_storage_bucket.this.name
-}
-
-resource "google_storage_bucket_object" "license_empty" {
-  count = contains([for f in values(var.files) : true if trimprefix(f, "license/") != f], true) ? 0 : 1
-
-  name    = "license/"
-  content = "license/"
-  bucket  = google_storage_bucket.this.name
-}
-
-resource "google_storage_bucket_object" "software_empty" {
-  count = contains([for f in values(var.files) : true if trimprefix(f, "software/") != f], true) ? 0 : 1
-
-  name    = "software/"
-  content = "software/"
-  bucket  = google_storage_bucket.this.name
 }
 
 data "google_compute_default_service_account" "this" {}

--- a/modules/bootstrap/outputs.tf
+++ b/modules/bootstrap/outputs.tf
@@ -5,4 +5,3 @@ output "bucket_name" {
 output "bucket" {
   value = google_storage_bucket.this
 }
-

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -20,3 +20,13 @@ variable "location" {
   description = "Location in which the GCS Bucket will be deployed. Available locations can be found under https://cloud.google.com/storage/docs/locations."
   type        = string
 }
+
+
+variable "folders" {
+  description = <<-EOF
+  A list of folder paths that will impact where the bootstrap package(s) folders will be created in.
+  A default value (empty list) will cause the bootstrap package folders to be created in the bucket root directory.
+  EOF
+  default     = []
+  type        = list(any)
+}

--- a/modules/bootstrap/variables.tf
+++ b/modules/bootstrap/variables.tf
@@ -24,8 +24,9 @@ variable "location" {
 
 variable "folders" {
   description = <<-EOF
-  A list of folder paths that will impact where the bootstrap package(s) folders will be created in.
-  A default value (empty list) will cause the bootstrap package folders to be created in the bucket root directory.
+  List of folder paths that will be used to create dedicated boostrap package folder sets per firewall or firewall group (for example to distinguish configuration per region, per inbound/obew role, etc) within the created storage bucket.
+
+  A default value (empty list) will result in the creation of a single bootstrap package folder set in the bucket top-level directory.
   EOF
   default     = []
   type        = list(any)

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.0, < 2.0"
   required_providers {
-    google = { version = "~> 3.30" }
+    google = { version = "~> 4.54" }
   }
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.0, < 2.0"
   required_providers {
-    google = { version = "~> 4.54" }
+    google = { version = "~> 3.30" }
   }
 }

--- a/modules/bootstrap/versions.tf
+++ b/modules/bootstrap/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15.3, < 2.0"
+  required_version = ">= 1.0, < 2.0"
   required_providers {
     google = { version = "~> 3.30" }
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Added a new variable called `folders` that can offer the capability to create bootstrap package folders inside a sub-folder in GCP bucket instead of the root bucket folder.
- This gives the module the capability to bootstrap multiple firewalls from the same bucket using sub-folders.
- This change is backwards-compatible with root bucket folder placement and will not affect other existing examples/usages of the module.
- This change is a pre-requisite for examples refactor.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- GCP examples refactoring.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Created instances of the bootstrap bucket both with specific folders as input and without any folder as input (to check backwards compatibility) .

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
