### PR TITLE
fix(examples/panorama_standalone): Deploy panorama without specifying log_disks

### DIFF
--- a/examples/panorama_standalone/main.tf
+++ b/examples/panorama_standalone/main.tf
@@ -22,6 +22,6 @@ module "panorama" {
   subnet            = module.vpc.subnetworks["${var.name_prefix}${each.value.panorama_subnet}"].self_link
   private_static_ip = each.value.private_static_ip
   attach_public_ip  = each.value.attach_public_ip
-  log_disks         = each.value.log_disks
+  log_disks         = try(each.value.log_disks, [])
   depends_on        = [module.vpc]
 }


### PR DESCRIPTION
## Description

Allow `examples/panorama_standalone` to be used without `log_disks` input parameter.

## Motivation and Context

Without this adjustment `examples/panorama_standalone` ends with an error when the example is used with out of the box parameters.

## How Has This Been Tested?

Test performed as described in README -> Build.

## Screenshots (if appropriate)

n/a

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
