### PR TITLE
fix(examples): Add beta provider settings when lb_internal is used

### DIFF
--- a/examples/autoscale/versions.tf
+++ b/examples/autoscale/versions.tf
@@ -9,3 +9,8 @@ provider "google" {
   project = var.project_id
   region  = var.region
 }
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}

--- a/examples/vpc_peering_common/versions.tf
+++ b/examples/vpc_peering_common/versions.tf
@@ -6,3 +6,8 @@ provider "google" {
   project = var.project
   region  = var.region
 }
+
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+}

--- a/examples/vpc_peering_common_with_network_tags/versions.tf
+++ b/examples/vpc_peering_common_with_network_tags/versions.tf
@@ -4,5 +4,8 @@ terraform {
 
 provider "google" {
   project = var.project
-  # region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project
 }

--- a/examples/vpc_peering_dedicated/versions.tf
+++ b/examples/vpc_peering_dedicated/versions.tf
@@ -6,3 +6,8 @@ provider "google" {
   project = var.project
   region  = var.region
 }
+
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+}

--- a/modules/lb_internal/README.md
+++ b/modules/lb_internal/README.md
@@ -49,6 +49,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name of the load balancer (that is, both the forwarding rule and the backend service) | `string` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | n/a | `any` | `null` | no |
 | <a name="input_ports"></a> [ports](#input\_ports) | Which port numbers are forwarded to the backends (up to 5 ports). Conflicts with all\_ports. | `list(number)` | `[]` | no |
+| <a name="input_project"></a> [project](#input\_project) | The project to deploy to. If unset the default provider project is used. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region to create ILB in. | `string` | `null` | no |
 | <a name="input_session_affinity"></a> [session\_affinity](#input\_session\_affinity) | Controls distribution of new connections (or fragmented UDP packets) from clients to the backends, can influence available connection tracking configurations.<br>Valid values are: NONE (default), CLIENT\_IP\_NO\_DESTINATION, CLIENT\_IP, CLIENT\_IP\_PROTO, CLIENT\_IP\_PORT\_PROTO. | `string` | `null` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | n/a | `string` | n/a | yes |

--- a/modules/lb_internal/main.tf
+++ b/modules/lb_internal/main.tf
@@ -1,7 +1,8 @@
 data "google_client_config" "this" {}
 
 resource "google_compute_health_check" "this" {
-  name = "${var.name}-${data.google_client_config.this.region}-check-tcp${var.health_check_port}"
+  name    = "${var.name}-${data.google_client_config.this.region}-check-tcp${var.health_check_port}"
+  project = var.project
 
   tcp_health_check {
     port = var.health_check_port
@@ -13,6 +14,7 @@ resource "google_compute_region_backend_service" "this" {
 
   name    = var.name
   network = var.network
+  project = var.project
   region  = var.region
 
   health_checks                   = [var.health_check != null ? var.health_check : google_compute_health_check.this.self_link]
@@ -58,8 +60,9 @@ resource "google_compute_region_backend_service" "this" {
 }
 
 resource "google_compute_forwarding_rule" "this" {
-  name   = var.name
-  region = var.region
+  name    = var.name
+  project = var.project
+  region  = var.region
 
   load_balancing_scheme = "INTERNAL"
   ip_address            = var.ip_address

--- a/modules/lb_internal/variables.tf
+++ b/modules/lb_internal/variables.tf
@@ -3,6 +3,12 @@ variable "name" {
   type        = string
 }
 
+variable "project" {
+  description = "The project to deploy to. If unset the default provider project is used."
+  type        = string
+  default     = null
+}
+
 variable "region" {
   description = "Region to create ILB in."
   type        = string


### PR DESCRIPTION
## Description

After adding connection tracking settings, that require google-beta provider, examples that use lb_internal got broken:
```
│ Error: project: required field is not set
│ 
│   with module.lb_internal["internal-lb"].google_compute_region_backend_service.this,
│   on ../../modules/lb_internal/main.tf line 12, in resource "google_compute_region_backend_service" "this":
│   12: resource "google_compute_region_backend_service" "this" {
```

While project/region are set for regular provider, it's missing for the beta one.

Additionally, added module level variable to allow to specify project directly at resource level.

## Motivation and Context

Bug fix.

## How Has This Been Tested?

Apply vpc_peering_common example.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
