### PR TITLE
fix(module/lb_internal): Remove data source from lb_internal

### DIFF
--- a/modules/lb_internal/main.tf
+++ b/modules/lb_internal/main.tf
@@ -1,7 +1,5 @@
-data "google_client_config" "this" {}
-
 resource "google_compute_health_check" "this" {
-  name    = "${var.name}-${data.google_client_config.this.region}-check-tcp${var.health_check_port}"
+  name    = "${var.name}-${var.region}-check-tcp${var.health_check_port}"
   project = var.project
 
   tcp_health_check {


### PR DESCRIPTION
## Description

Remove data source and use `var.region` directly.
This PR closes #220 .

## Motivation and Context

Issue with multi-region example deployment.

## How Has This Been Tested?

Local terraform plan .

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
