### PR TITLE
fix(module/autoscale): Null delicensing_cloud_function_config config fixed

### DIFF
--- a/examples/autoscale/main.tf
+++ b/examples/autoscale/main.tf
@@ -128,7 +128,7 @@ module "autoscale" {
   service_account_email = module.iam_service_account.email
   target_pools          = [module.extlb.target_pool]
 
-  delicensing_cloud_function_config = try(var.delicensing_cloud_function_config, {})
+  delicensing_cloud_function_config = try(var.delicensing_cloud_function_config, null)
 
   network_interfaces = [
     {

--- a/modules/autoscale/main.tf
+++ b/modules/autoscale/main.tf
@@ -200,12 +200,12 @@ resource "random_id" "postfix" {
 }
 
 locals {
-  name_prefix   = try(var.delicensing_cloud_function_config.name_prefix) == null ? "" : try(var.delicensing_cloud_function_config.name_prefix)
+  name_prefix   = try(var.delicensing_cloud_function_config.name_prefix, "")
   function_name = coalesce(try(var.delicensing_cloud_function_config.function_name, "delicensing-cfn"), "delicensing-cfn")
   delicensing_cfn = {
-    panorama_address        = var.delicensing_cloud_function_config.panorama_address
+    panorama_address        = try(var.delicensing_cloud_function_config.panorama_address, "")
     panorama2_address       = try(var.delicensing_cloud_function_config.panorama2_address, "")
-    function_name           = "${local.name_prefix}${local.function_name}-${random_id.postfix.hex}",
+    function_name           = "${local.name_prefix}${local.function_name}-${random_id.postfix.hex}"
     bucket_name             = "${local.name_prefix}${local.function_name}-${random_id.postfix.hex}"
     source_dir              = "${path.module}/src"
     zip_file_name           = local.function_name


### PR DESCRIPTION
## Description

When running `examples/autoscaling` if `delicensing_cloud_function_config = null` the example fails to run.
See issue for details.

## Motivation and Context

PR fixes issue #222 

## How Has This Been Tested?

Terraform plan & apply for the `autoscale` example.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
