### PR TITLE
fix(module/vmseries): Reuse of existing public IP for 1 NIC caused creating ephemeral IPs for other NICs

### DIFF
--- a/examples/multi_nic_common/main.tf
+++ b/examples/multi_nic_common/main.tf
@@ -144,6 +144,7 @@ module "vmseries" {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       private_ip       = v.private_ip
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
 }
 

--- a/examples/standalone_vmseries_with_metadata_bootstrap/main.tf
+++ b/examples/standalone_vmseries_with_metadata_bootstrap/main.tf
@@ -43,5 +43,6 @@ module "vmseries" {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       private_ip       = v.private_ip
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
 }

--- a/examples/vmseries_ha/main.tf
+++ b/examples/vmseries_ha/main.tf
@@ -148,6 +148,7 @@ module "vmseries" {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       private_ip       = v.private_ip
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
 }
 

--- a/examples/vpc_peering_common/main.tf
+++ b/examples/vpc_peering_common/main.tf
@@ -142,6 +142,7 @@ module "vmseries" {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       private_ip       = v.private_ip
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
 }
 

--- a/examples/vpc_peering_common_with_autoscale/main.tf
+++ b/examples/vpc_peering_common_with_autoscale/main.tf
@@ -99,6 +99,7 @@ module "autoscale" {
     {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
   metadata = merge(
     try(each.value.bootstrap_options, {}),

--- a/examples/vpc_peering_common_with_network_tags/main.tf
+++ b/examples/vpc_peering_common_with_network_tags/main.tf
@@ -143,6 +143,7 @@ module "vmseries" {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       private_ip       = v.private_ip
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
 }
 

--- a/examples/vpc_peering_dedicated/main.tf
+++ b/examples/vpc_peering_dedicated/main.tf
@@ -142,6 +142,7 @@ module "vmseries" {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       private_ip       = v.private_ip
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
 }
 

--- a/examples/vpc_peering_dedicated_with_autoscale/main.tf
+++ b/examples/vpc_peering_dedicated_with_autoscale/main.tf
@@ -99,6 +99,7 @@ module "autoscale" {
     {
       subnetwork       = module.vpc[v.vpc_network_key].subnetworks[v.subnetwork_key].self_link
       create_public_ip = try(v.create_public_ip, false)
+      public_ip        = try(v.public_ip, null)
   }]
   metadata = merge(
     try(each.value.bootstrap_options, {}),

--- a/modules/vmseries/main.tf
+++ b/modules/vmseries/main.tf
@@ -7,7 +7,7 @@ locals {
       nat_ip                 = try(v.public_ip, google_compute_address.public[k].address, null)
       public_ptr_domain_name = try(v.public_ptr_domain_name, google_compute_address.public[k].public_ptr_domain_name, null)
     }
-    if can(v.public_ip) || local.create_public_ip[k]
+    if try(v.public_ip, null) != null || local.create_public_ip[k]
   }
 }
 


### PR DESCRIPTION
## Description

PR delivers fix for module `vmseries`, which resolve following problem : after adding existing public IPs for one or more NICs, for the rest of the NICs code was creating ephemeral, external IPs. 

## Motivation and Context

Customer opened an issue, in which:
- they had VM-Series with 3 NICs 
- they add BYOIP to the interface NIC0
- in the same time NIC1 and NIC2 were getting unwanted GCP public IP addresses 

In the lab it was checked following scenario, where in the example code for 1 VM-Series instead of creating public IPs:

https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules/blob/f7ffbe0a4eb0d4281c01096db2252483d0285a07/examples/vpc_peering_common/example.tfvars#L258-L276

there were reused existing IPs:

```
    network_interfaces = [
      {
        vpc_network_key = "fw-untrust-vpc"
        subnetwork_key  = "fw-untrust-sub"
        private_ip      = "10.10.11.2"
        public_ip       = "A1.B1.C1.D1"
      },
      {
        vpc_network_key = "fw-mgmt-vpc"
        subnetwork_key  = "fw-mgmt-sub"
        private_ip      = "10.10.10.2"
        public_ip       = "A2.B2.C2.D2"
      },
      {
        vpc_network_key = "fw-trust-vpc"
        subnetwork_key  = "fw-trust-sub"
        private_ip      = "10.10.12.2"
      }
    ]
```

where `A1.B1.C1.D1` and `A2.B2.C2.D2` represents some public IPs.

After changing TFVARS, it was added `public_ip` in example `vpc_peering_common`:

https://github.com/PaloAltoNetworks/terraform-google-vmseries-modules/blob/f7ffbe0a4eb0d4281c01096db2252483d0285a07/examples/vpc_peering_common/main.tf#L140-L145

Then while after applying changes on already deployed infrastructure Terraform was adding empty access config for the 3 NIC, which shouldn't have public IP:

```
Terraform will perform the following actions:

  # module.vmseries["fw-vmseries-01"].google_compute_instance.this will be updated in-place
  ~ resource "google_compute_instance" "this" {
        id                        = "projects/gcp-gcs-pso/zones/europe-west2-b/instances/sczechfw-vmseries-01"
        name                      = "sczechfw-vmseries-01"
        tags                      = [
            "vmseries",
        ]
        # (19 unchanged attributes hidden)

      ~ network_interface {
            name                        = "nic2"
            # (7 unchanged attributes hidden)

          + access_config {}
        }

        # (5 unchanged blocks hidden)
    }

  # module.vmseries["fw-vmseries-02"].google_compute_instance.this will be updated in-place
  ~ resource "google_compute_instance" "this" {
        id                        = "projects/gcp-gcs-pso/zones/europe-west2-c/instances/sczechfw-vmseries-02"
        name                      = "sczechfw-vmseries-02"
        tags                      = [
            "vmseries",
        ]
        # (19 unchanged attributes hidden)

      ~ network_interface {
            name                        = "nic2"
            # (7 unchanged attributes hidden)

          + access_config {}
        }

        # (5 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.

Changes to Outputs:
  ~ vmseries_public_ips  = {
      ~ fw-vmseries-01 = {
          + "2" = null
            # (2 unchanged attributes hidden)
        }
      ~ fw-vmseries-02 = {
          + "2" = null
            # (2 unchanged attributes hidden)
        }
    }
```

## How Has This Been Tested?

Code was tested by changing module `vmseries` and applying example `vpc_peering_common`.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
