### PR TITLE
fix(examples): Add 'name_prefix' for external lb rules

### DIFF
--- a/examples/multi_nic_common/main.tf
+++ b/examples/multi_nic_common/main.tf
@@ -207,7 +207,7 @@ module "lb_external" {
 
   name                    = "${var.name_prefix}${each.value.name}"
   backend_instance_groups = { for v in each.value.backends : v => module.vmseries[v].instance_group_self_link }
-  rules                   = each.value.rules
+  rules                   = { for k, v in each.value.rules : "${var.name_prefix}${k}" => v }
 
   health_check_http_port         = each.value.http_health_check_port
   health_check_http_request_path = try(each.value.http_health_check_request_path, "/php/login.php")

--- a/examples/vmseries_ha/main.tf
+++ b/examples/vmseries_ha/main.tf
@@ -212,7 +212,7 @@ module "lb_external" {
 
   name                    = "${var.name_prefix}${each.value.name}"
   backend_instance_groups = { for v in each.value.backends : v => module.vmseries[v].instance_group_self_link }
-  rules                   = each.value.rules
+  rules                   = { for k, v in each.value.rules : "${var.name_prefix}${k}" => v }
 
   health_check_http_port         = each.value.http_health_check_port
   health_check_http_request_path = try(each.value.http_health_check_request_path, "/php/login.php")

--- a/examples/vpc_peering_common/main.tf
+++ b/examples/vpc_peering_common/main.tf
@@ -205,7 +205,7 @@ module "lb_external" {
 
   name                    = "${var.name_prefix}${each.value.name}"
   backend_instance_groups = { for v in each.value.backends : v => module.vmseries[v].instance_group_self_link }
-  rules                   = each.value.rules
+  rules                   = { for k, v in each.value.rules : "${var.name_prefix}${k}" => v }
 
   health_check_http_port         = each.value.http_health_check_port
   health_check_http_request_path = try(each.value.http_health_check_request_path, "/php/login.php")

--- a/examples/vpc_peering_common_with_autoscale/main.tf
+++ b/examples/vpc_peering_common_with_autoscale/main.tf
@@ -177,7 +177,7 @@ module "lb_external" {
       "${v}_${z_k}" => module.autoscale[v].zonal_instance_group_ids[z_k]
     }
   ]...)
-  rules = each.value.rules
+  rules = { for k, v in each.value.rules : "${var.name_prefix}${k}" => v }
 
   health_check_http_port         = each.value.http_health_check_port
   health_check_http_request_path = try(each.value.http_health_check_request_path, "/php/login.php")

--- a/examples/vpc_peering_common_with_network_tags/main.tf
+++ b/examples/vpc_peering_common_with_network_tags/main.tf
@@ -211,7 +211,7 @@ module "lb_external" {
 
   name                    = "${var.name_prefix}${each.value.name}-${each.value.region}"
   backend_instance_groups = { for v in each.value.backends : v => module.vmseries[v].instance_group_self_link }
-  rules                   = each.value.rules
+  rules                   = { for k, v in each.value.rules : "${var.name_prefix}${k}" => v }
 
   health_check_http_port         = each.value.http_health_check_port
   health_check_http_request_path = try(each.value.http_health_check_request_path, "/php/login.php")

--- a/examples/vpc_peering_dedicated_with_autoscale/main.tf
+++ b/examples/vpc_peering_dedicated_with_autoscale/main.tf
@@ -177,7 +177,7 @@ module "lb_external" {
       "${v}_${z_k}" => module.autoscale[v].zonal_instance_group_ids[z_k]
     }
   ]...)
-  rules = each.value.rules
+  rules = { for k, v in each.value.rules : "${var.name_prefix}${k}" => v }
 
   health_check_http_port         = each.value.http_health_check_port
   health_check_http_request_path = try(each.value.http_health_check_request_path, "/php/login.php")


### PR DESCRIPTION
## Description

Add `name_prefix` in front of external LB rule names in the examples to avoid name collisions in CI/release workflows.

## Motivation and Context

Resolves #233 

## How Has This Been Tested?

Apply `vpc_peering_common` example.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
